### PR TITLE
Align AWS discovery release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,10 @@
 name: Release
 
 on:
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
-    inputs:
-      tag:
-        description: Release tag (for example v0.2.3)
-        required: true
-        type: string
 
 permissions:
   contents: write
@@ -17,33 +15,52 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
       - uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: npm
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.24'
       - run: npm ci
-      - run: npm run build
       - run: npm test
-      - name: Create git tag
+      - run: npm run typecheck
+      - run: npm run check:dist
+      - name: Install actionlint
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.11
+      - name: Run actionlint
         run: |
-          git tag "${{ inputs.tag }}"
-          git push origin "${{ inputs.tag }}"
+          ACTIONLINT_BIN="$(go env GOPATH)/bin/actionlint"
+          "$ACTIONLINT_BIN"
+      - name: Verify release tag matches package version
+        run: |
+          if [[ "$GITHUB_REF" != refs/tags/v* ]]; then
+            echo "::error::Release workflow must run from a v* tag; got $GITHUB_REF"
+            exit 1
+          fi
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          IFS='.' read -r MAJOR MINOR PATCH _ <<< "$PKG_VERSION"
+          ALLOWED_TAGS=("$PKG_VERSION" "$MAJOR")
+          if [ "${PATCH:-}" = "0" ] && [ -n "${MINOR:-}" ]; then
+            ALLOWED_TAGS+=("$MAJOR.$MINOR")
+          fi
+          for ALLOWED_TAG in "${ALLOWED_TAGS[@]}"; do
+            if [ "$TAG_VERSION" = "$ALLOWED_TAG" ]; then
+              exit 0
+            fi
+          done
+          if [ "${#ALLOWED_TAGS[@]}" -eq 3 ]; then
+            EXPECTED="v${ALLOWED_TAGS[0]}, v${ALLOWED_TAGS[1]}, or v${ALLOWED_TAGS[2]}"
+          else
+            EXPECTED="v${ALLOWED_TAGS[0]} or v${ALLOWED_TAGS[1]}"
+          fi
+          echo "::error::Tag v$TAG_VERSION does not match package.json version $PKG_VERSION; expected $EXPECTED"
+          exit 1
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ inputs.tag }}
           generate_release_notes: true
-      - name: Verify version matches tag
-        run: |
-          TAG="${{ inputs.tag }}"
-          TAG="${TAG#v}"
-          PKG_VERSION=$(node -p "require('./package.json').version")
-          if [ "$TAG" != "$PKG_VERSION" ]; then
-            echo "::error::Tag v$TAG does not match package.json version $PKG_VERSION"
-            exit 1
-          fi
       - uses: actions/setup-node@v5
         with:
           node-version: '24'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-aws-spec-discovery",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-aws-spec-discovery",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-aws-spec-discovery",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Discover and export API specs from AWS services with zero-config auto-detection.",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Summary
- Align AWS discovery release to the tag-push workflow used by the other action repos.
- Move package version validation before GitHub release creation and accept supported v0 / zero-patch minor tags.
- Bump package to 0.7.3 for a clean release through the aligned workflow.

## Validation
- npm test
- npm run typecheck
- npm run lint
- npm run check:dist
- actionlint -color=false