### PR TITLE
fix: keep v0.x release tags publishable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,25 +42,25 @@ jobs:
           TAG_VERSION="${GITHUB_REF_NAME#v}"
           PKG_VERSION=$(node -p "require('./package.json').version")
           IFS='.' read -r MAJOR MINOR PATCH _ <<< "$PKG_VERSION"
-          ALIAS_TAGS=("$MAJOR")
+          PUBLISH_TAGS=("$PKG_VERSION")
           if [ "${PATCH:-}" = "0" ] && [ -n "${MINOR:-}" ]; then
-            ALIAS_TAGS+=("$MAJOR.$MINOR")
+            PUBLISH_TAGS+=("$MAJOR.$MINOR")
           fi
-          if [ "$TAG_VERSION" = "$PKG_VERSION" ]; then
-            echo "npm_publish=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          for ALIAS_TAG in "${ALIAS_TAGS[@]}"; do
-            if [ "$TAG_VERSION" = "$ALIAS_TAG" ]; then
-              echo "npm_publish=false" >> "$GITHUB_OUTPUT"
-              echo "::notice::Tag v$TAG_VERSION is a rolling customer preview alias for package version $PKG_VERSION; skipping npm publish."
+          for PUBLISH_TAG in "${PUBLISH_TAGS[@]}"; do
+            if [ "$TAG_VERSION" = "$PUBLISH_TAG" ]; then
+              echo "npm_publish=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
           done
-          if [ "${#ALIAS_TAGS[@]}" -eq 2 ]; then
-            EXPECTED="v$PKG_VERSION, v${ALIAS_TAGS[0]}, or v${ALIAS_TAGS[1]}"
+          if [ "$TAG_VERSION" = "$MAJOR" ]; then
+            echo "npm_publish=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Tag v$TAG_VERSION is the rolling customer preview alias for package version $PKG_VERSION; skipping npm publish."
+            exit 0
+          fi
+          if [ "${#PUBLISH_TAGS[@]}" -eq 2 ]; then
+            EXPECTED="v${PUBLISH_TAGS[0]}, v${PUBLISH_TAGS[1]}, or v$MAJOR"
           else
-            EXPECTED="v$PKG_VERSION or v${ALIAS_TAGS[0]}"
+            EXPECTED="v${PUBLISH_TAGS[0]} or v$MAJOR"
           fi
           echo "::error::Tag v$TAG_VERSION does not match package.json version $PKG_VERSION; expected $EXPECTED"
           exit 1
@@ -73,8 +73,20 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-      - name: Publish to npm
+      - name: Check npm package version
+        id: npm_package
         if: steps.release_tag.outputs.npm_publish == 'true'
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::$PKG_NAME@$PKG_VERSION is already published; skipping npm publish."
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Publish to npm
+        if: steps.release_tag.outputs.npm_publish == 'true' && steps.npm_package.outputs.already_published != 'true'
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -17,20 +17,24 @@ function npmRegistrySetupStep(): string {
 }
 
 describe('release workflow publishing contract', () => {
-  it('treats rolling aliases as release tags but not npm publish tags', () => {
-    expect(releaseWorkflow).toContain('ALIAS_TAGS=("$MAJOR")');
-    expect(releaseWorkflow).toContain('ALIAS_TAGS+=("$MAJOR.$MINOR")');
+  it('keeps v0 as the only rolling alias and v0.x as a zero-patch publish tag', () => {
+    expect(releaseWorkflow).toContain('PUBLISH_TAGS=("$PKG_VERSION")');
+    expect(releaseWorkflow).toContain('PUBLISH_TAGS+=("$MAJOR.$MINOR")');
+    expect(releaseWorkflow).toContain('if [ "$TAG_VERSION" = "$MAJOR" ]; then');
     expect(releaseWorkflow).toContain('echo "npm_publish=true" >> "$GITHUB_OUTPUT"');
     expect(releaseWorkflow).toContain('echo "npm_publish=false" >> "$GITHUB_OUTPUT"');
     expect(releaseWorkflow).toContain('skipping npm publish');
-    expect(releaseWorkflow).not.toContain('PUBLISH_TAGS');
+    expect(releaseWorkflow).not.toContain('ALIAS_TAGS');
     expect(releaseWorkflow).not.toContain('publish_tag');
   });
 
-  it('keeps GitHub release artifacts for aliases while gating only npm publication', () => {
+  it('keeps GitHub release artifacts while making npm publication idempotent', () => {
     expect(namedStep('Publish GitHub release')).not.toMatch(/\n\s+if:/);
     expect(npmRegistrySetupStep()).toContain("if: steps.release_tag.outputs.npm_publish == 'true'");
-    expect(namedStep('Publish to npm')).toContain("if: steps.release_tag.outputs.npm_publish == 'true'");
+    expect(namedStep('Check npm package version')).toContain('id: npm_package');
+    expect(namedStep('Check npm package version')).toContain('npm view "$PKG_NAME@$PKG_VERSION" version');
+    expect(namedStep('Check npm package version')).toContain('already_published=true');
+    expect(namedStep('Publish to npm')).toContain("if: steps.release_tag.outputs.npm_publish == 'true' && steps.npm_package.outputs.already_published != 'true'");
     expect(namedStep('Attach npm tarball to release')).not.toMatch(/\n\s+if:/);
     expect(namedStep('Upload tarball')).not.toMatch(/\n\s+if:/);
   });


### PR DESCRIPTION
## Summary
- keep zero-patch v0.x tags publishable, matching RELEASE_POLICY.md immutable tag guidance
- keep v0 as the only rolling non-npm alias
- add an npm registry existence check so pushing both v0.x and v0.x.0 does not fail on duplicate package publication
- update release workflow regression tests to lock the policy

## Validation
- release workflow regression tests in all repos
- npm test / typecheck / lint / build / check:dist / actionlint where deterministic
- note: local bootstrap full npm test currently hangs in its package CLI npm install smoke test; the release-workflow test and deterministic validators passed