### PR TITLE
docs: adopt Postman API Onboarding suite naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# Postman AWS Spec Discovery
+# Postman Onboarding: AWS Spec Discovery
 
 [![CI](https://github.com/postman-cs/postman-aws-spec-discovery-action/actions/workflows/ci.yml/badge.svg)](https://github.com/postman-cs/postman-aws-spec-discovery-action/actions/workflows/ci.yml) [![Release](https://img.shields.io/github/v/release/postman-cs/postman-aws-spec-discovery-action?sort=semver)](https://github.com/postman-cs/postman-aws-spec-discovery-action/releases) [![npm](https://img.shields.io/npm/v/%40postman-cse%2Fonboarding-aws-spec-discovery)](https://www.npmjs.com/package/@postman-cse/onboarding-aws-spec-discovery) [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 Zero-config discovery and export of API specs from AWS services using only your existing AWS credentials.
+
+Part of the [Postman API Onboarding suite](https://github.com/postman-cs/postman-api-onboarding-action).
 
 You usually set just `aws-region`. Repo identity comes from CI automatically, providers are auto-detected by probing your IAM permissions, and repo-first resolution prefers existing specs before calling AWS. No GitHub token required; the action is read-only against AWS APIs.
 
@@ -199,6 +201,18 @@ At startup the action validates credentials with `sts:GetCallerIdentity`, probes
 SNS is handled as a contract resolver, since SNS has no native exportable spec. Contracts resolve through a 9-level precedence chain (repo-local AsyncAPI down to manual review), with subscription-aware enrichment and metadata/webhook sidecars. See [docs/sns-contract-resolution.md](docs/sns-contract-resolution.md).
 
 ## Resources
+
+### The suite
+
+| Action | Role |
+| --- | --- |
+| [Postman API Onboarding](https://github.com/postman-cs/postman-api-onboarding-action) | Entry point: chains workspace bootstrap, repo sync, and optional Insights linking |
+| [Postman Onboarding: Service Token](https://github.com/postman-cs/postman-resolve-service-token-action) | Mints the service-account access token and team ID |
+| [Postman Onboarding: AWS Spec Discovery](https://github.com/postman-cs/postman-aws-spec-discovery-action) | Discovers and exports API specs from AWS services |
+| [Postman Onboarding: Workspace Bootstrap](https://github.com/postman-cs/postman-bootstrap-action) | Creates the workspace, uploads the spec, generates collections |
+| [Postman Onboarding: Smoke Flow](https://github.com/postman-cs/postman-smoke-flow-action) | Applies a curated flow.yaml to the Smoke collection |
+| [Postman Onboarding: Repo Sync](https://github.com/postman-cs/postman-repo-sync-action) | Exports artifacts into the repo and wires CI, mocks, and monitors |
+| [Postman Onboarding: Insights Linking](https://github.com/postman-cs/postman-insights-onboarding-action) | Links Insights discovered services to the workspace |
 
 - [postman-resolve-service-token-action](https://github.com/postman-cs/postman-resolve-service-token-action): mints a service-account access token and team ID
 - [postman-api-onboarding-action](https://github.com/postman-cs/postman-api-onboarding-action): composite that orchestrates the onboarding pipeline

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: Postman AWS Spec Discovery
-description: Zero-config discovery and export of API specs from AWS services using only your existing AWS credentials.
+name: 'Postman Onboarding: AWS Spec Discovery'
+description: Zero-config discovery and export of API specs from AWS services. Part of the Postman API Onboarding suite.
 author: Postman
 branding:
   icon: cloud

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-aws-spec-discovery",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-aws-spec-discovery",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-aws-spec-discovery",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Discover and export API specs from AWS services with zero-config auto-detection.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/validation/README.md
+++ b/validation/README.md
@@ -2,7 +2,7 @@
 
 This directory is the customer-facing validation package for the AWS spec discovery action. It documents how each discovery surface is exercised, what artifact the action emits, and whether that artifact is already OpenAPI or can be represented as a partial OpenAPI 3.x document.
 
-The validation package is intended to answer three questions:
+The package answers three questions:
 
 1. Which discovery surfaces are supported?
 2. How can a customer reproduce the behavior?
@@ -54,7 +54,7 @@ That file is gitignored. Commit only the sanitized evidence summary in `evidence
 
 The stack includes dedicated live resources for API Gateway, AppSync, AppSync Events, EventBridge Schemas, EventBridge rules/pipes/API destinations, CloudFormation, Glue, SSM, SNS, Lambda Function URLs, Lambda event source mappings, Verified Permissions, Step Functions, ALB listener rules, and Bedrock Agent action groups.
 
-## Reproduce The Full Validation Set
+## Reproduce the Full Validation Set
 
 Run from the action repository root:
 
@@ -90,7 +90,7 @@ aws cloudformation deploy \
   --parameter-overrides AlbVpcId="$ALB_VPC_ID" AlbSubnetIds="$ALB_SUBNET_IDS"
 ```
 
-## Reading The Evidence
+## Reading the Evidence
 
 - `evidence/README.md` is the single customer-facing evidence summary and coverage matrix for every discovery surface.
 - Raw matrix details are stored only in gitignored `*.local.json` files.


### PR DESCRIPTION
Suite naming across the listing surface: title prefix, suite suffix in the action description, suite line under the tagline, and a uniform suite table under Resources. Version bump for the listing-refresh release.