### PR TITLE
feat: optional access-token telemetry account_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,9 +344,11 @@ DO_NOT_TRACK=1
 
 Telemetry is also skipped automatically when no Postman team ID can be resolved.
 
-This action holds no Postman credentials, so telemetry is present but inert
-unless a `POSTMAN_TEAM_ID` environment variable is supplied to attribute the
-run to a team.
+This action performs no Postman asset operation, so telemetry stays inert unless
+a `POSTMAN_TEAM_ID` environment variable is supplied to attribute the run to a
+team. The optional `postman-api-key` / `postman-access-token` inputs are used
+only to resolve the session `account_type` for that telemetry event; they never
+touch discovery, which runs entirely on AWS credentials.
 
 Events are sent over HTTPS to `https://events.pm-cse.dev/v1/events`. To
 allowlist this destination on a restricted network, or to route events to a

--- a/README.md
+++ b/README.md
@@ -216,7 +216,8 @@ CLI environment-variable outputs are documented in [docs/providers.md](docs/prov
 | `gateway-id` | Optional known API Gateway ID for this service. Use this when you want to bypass broader account discovery. | no | n/a |
 | `stage` | Optional API Gateway stage override (for example prod or staging). | no | n/a |
 | `output-dir` | Directory under the repository root where generated specs are written. | no | `discovered-specs` |
-| `postman-access-token` | Optional Postman service-account access token, used only to enrich anonymous telemetry with the session account_type. Not used for any AWS or Postman asset operation. | no | n/a |
+| `postman-api-key` | Optional service-account PMAK used to mint or re-mint a postman-access-token for telemetry enrichment (account_type). Not used for any AWS or Postman asset operation. | no | n/a |
+| `postman-access-token` | Optional Postman service-account access token, used only to enrich anonymous telemetry with the session account_type. When omitted, postman-api-key alone can mint one for the same purpose. Not used for any AWS or Postman asset operation. | no | n/a |
 <!-- inputs-table:end -->
 
 Optional resolution tuning inputs (`mode`, `expected-service-name`, `api-filter`, `max-candidates`, repo context overrides, and more) are set via `INPUT_`-prefixed environment variables and documented in [docs/providers.md](docs/providers.md#resolution-tuning-inputs).

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ CLI environment-variable outputs are documented in [docs/providers.md](docs/prov
 | `gateway-id` | Optional known API Gateway ID for this service. Use this when you want to bypass broader account discovery. | no | n/a |
 | `stage` | Optional API Gateway stage override (for example prod or staging). | no | n/a |
 | `output-dir` | Directory under the repository root where generated specs are written. | no | `discovered-specs` |
+| `postman-access-token` | Optional Postman service-account access token, used only to enrich anonymous telemetry with the session account_type. Not used for any AWS or Postman asset operation. | no | n/a |
 <!-- inputs-table:end -->
 
 Optional resolution tuning inputs (`mode`, `expected-service-name`, `api-filter`, `max-candidates`, repo context overrides, and more) are set via `INPUT_`-prefixed environment variables and documented in [docs/providers.md](docs/providers.md#resolution-tuning-inputs).

--- a/action.yml
+++ b/action.yml
@@ -20,8 +20,12 @@ inputs:
     description: Directory under the repository root where generated specs are written.
     required: false
     default: discovered-specs
+  postman-api-key:
+    description: Optional service-account PMAK used to mint or re-mint a postman-access-token for telemetry enrichment (account_type). Not used for any AWS or Postman asset operation.
+    required: false
+    default: ''
   postman-access-token:
-    description: Optional Postman service-account access token, used only to enrich anonymous telemetry with the session account_type. Not used for any AWS or Postman asset operation.
+    description: Optional Postman service-account access token, used only to enrich anonymous telemetry with the session account_type. When omitted, postman-api-key alone can mint one for the same purpose. Not used for any AWS or Postman asset operation.
     required: false
     default: ''
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: Directory under the repository root where generated specs are written.
     required: false
     default: discovered-specs
+  postman-access-token:
+    description: Optional Postman service-account access token, used only to enrich anonymous telemetry with the session account_type. Not used for any AWS or Postman asset operation.
+    required: false
+    default: ''
 outputs:
   resolution-json:
     description: JSON resolution result describing status, source type, confidence, and evidence.

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -159854,6 +159854,11 @@ var actionContract = {
       description: "Directory under the repository root where generated specs are written.",
       required: false,
       default: "discovered-specs"
+    },
+    "postman-access-token": {
+      description: "Optional Postman service-account access token, used only to enrich anonymous telemetry with the session account_type. Not used for any AWS or Postman asset operation.",
+      required: false,
+      default: ""
     }
   },
   outputs: {
@@ -168125,6 +168130,93 @@ async function execute(inputs, dependencies) {
   };
 }
 
+// src/lib/postman/credential-identity.ts
+var sessionPath = "/api/sessions/current";
+var DEFAULT_IAPUB_BASE_URL = "https://iapub.postman.co";
+var sessionMemo = /* @__PURE__ */ new Map();
+var memoizedSessionIdentity;
+function asRecord(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return void 0;
+  }
+  return value;
+}
+function coerceId(raw) {
+  return raw ? String(raw) : void 0;
+}
+function coerceText(raw) {
+  if (typeof raw !== "string") {
+    return void 0;
+  }
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : void 0;
+}
+function normalizeBaseUrl(raw) {
+  return String(raw || "").replace(/\/+$/, "");
+}
+async function resolveSessionIdentity(opts) {
+  const accessToken = String(opts.accessToken || "").trim();
+  if (!accessToken) {
+    return void 0;
+  }
+  const baseUrl = normalizeBaseUrl(opts.iapubBaseUrl);
+  const memoKey = `${baseUrl}::${accessToken}`;
+  let pending = sessionMemo.get(memoKey);
+  if (!pending) {
+    pending = probeSessionIdentity(baseUrl, accessToken, opts.fetchImpl ?? fetch);
+    sessionMemo.set(memoKey, pending);
+  }
+  return pending;
+}
+async function resolveTelemetryAccountType(accessToken, fetchImpl) {
+  const token = String(accessToken || "").trim();
+  if (!token) {
+    return void 0;
+  }
+  const identity = await resolveSessionIdentity({
+    iapubBaseUrl: DEFAULT_IAPUB_BASE_URL,
+    accessToken: token,
+    ...fetchImpl ? { fetchImpl } : {}
+  }).catch(() => void 0);
+  return identity?.consumerType;
+}
+async function probeSessionIdentity(baseUrl, accessToken, fetchImpl) {
+  try {
+    const response = await fetchImpl(`${baseUrl}${sessionPath}`, {
+      method: "GET",
+      headers: { "x-access-token": accessToken }
+    });
+    if (!response.ok) {
+      return void 0;
+    }
+    const payload2 = asRecord(await response.json());
+    if (!payload2) {
+      return void 0;
+    }
+    const root5 = asRecord(payload2.session) ?? payload2;
+    const identity = asRecord(root5.identity);
+    const data2 = asRecord(root5.data);
+    const user = asRecord(data2?.user);
+    const roleEntries = Array.isArray(user?.roles) ? user.roles.map((entry) => coerceText(entry) ?? coerceId(entry)).filter((entry) => Boolean(entry)) : [];
+    const singleRole = coerceText(user?.role);
+    const roles = roleEntries.length > 0 ? roleEntries : singleRole ? [singleRole] : void 0;
+    const resolved = {
+      source: "iapub/sessions",
+      userId: coerceId(identity?.user) ?? coerceId(user?.id),
+      fullName: coerceText(user?.fullName) ?? coerceText(user?.name) ?? coerceText(user?.username),
+      teamId: coerceId(identity?.team),
+      teamName: coerceText(user?.teamName),
+      teamDomain: coerceText(identity?.domain),
+      ...roles ? { roles } : {},
+      consumerType: coerceText(root5.consumerType) ?? coerceText(data2?.consumerType) ?? coerceText(user?.consumerType)
+    };
+    memoizedSessionIdentity = resolved;
+    return resolved;
+  } catch {
+    return void 0;
+  }
+}
+
 // node_modules/@postman-cse/automation-telemetry-core/dist/ci-context.js
 function norm(value) {
   const trimmed = (value ?? "").trim();
@@ -168613,6 +168705,9 @@ async function runCli(argv = process.argv.slice(2)) {
   const reporter = new ConsoleReporter();
   const telemetry = createTelemetryContext({ action: "postman-aws-spec-discovery-action", logger: reporter });
   telemetry.setTeamId(config.inputEnv.POSTMAN_TEAM_ID ?? process.env.POSTMAN_TEAM_ID);
+  const accountType = await resolveTelemetryAccountType(
+    config.inputEnv.INPUT_POSTMAN_ACCESS_TOKEN ?? process.env.POSTMAN_ACCESS_TOKEN
+  );
   try {
     const result = await execute(inputs, {
       core: reporter,
@@ -168626,8 +168721,10 @@ async function runCli(argv = process.argv.slice(2)) {
     await writeOptionalFile(config.dotenvPath, toDotenv(result.outputs));
     process.stdout.write(`${JSON.stringify(result, null, 2)}
 `);
+    telemetry.setAccountType(accountType);
     telemetry.emitCompletion("success");
   } catch (error2) {
+    telemetry.setAccountType(accountType);
     telemetry.emitCompletion("failure");
     throw error2;
   }

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -14842,7 +14842,7 @@ var require_dist_cjs8 = __commonJS({
         req.end();
       });
     }
-    var retry = (toRetry, maxRetries) => {
+    var retry2 = (toRetry, maxRetries) => {
       let promise = toRetry();
       for (let i5 = 0; i5 < maxRetries; i5++) {
         promise = promise.catch(toRetry);
@@ -14854,7 +14854,7 @@ var require_dist_cjs8 = __commonJS({
     var ENV_CMDS_AUTH_TOKEN = "AWS_CONTAINER_AUTHORIZATION_TOKEN";
     var fromContainerMetadata = (init = {}) => {
       const { timeout, maxRetries } = providerConfigFromInit(init);
-      return () => retry(async () => {
+      return () => retry2(async () => {
         const requestOptions = await getCmdsUri({ logger: init.logger });
         const credsResponse = JSON.parse(await requestFromEcsImds(timeout, requestOptions));
         if (!isImdsCredentials(credsResponse)) {
@@ -15046,7 +15046,7 @@ For more information, please visit: ` + STATIC_STABILITY_DOC_URL);
             throw new InstanceMetadataV1FallbackError(`AWS EC2 Metadata v1 fallback has been blocked by AWS SDK configuration in the following: [${causes.join(", ")}].`);
           }
         }
-        const imdsProfile = (await retry(async () => {
+        const imdsProfile = (await retry2(async () => {
           let profile2;
           try {
             profile2 = await getProfile(options);
@@ -15058,7 +15058,7 @@ For more information, please visit: ` + STATIC_STABILITY_DOC_URL);
           }
           return profile2;
         }, maxRetries2)).trim();
-        return retry(async () => {
+        return retry2(async () => {
           let creds;
           try {
             creds = await getCredentialsFromProfile(imdsProfile, options, init);
@@ -30191,7 +30191,7 @@ var require_dist_cjs20 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider();
     var runtimeConfig = require_runtimeConfig();
@@ -30261,7 +30261,7 @@ var require_dist_cjs20 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -30270,7 +30270,7 @@ var require_dist_cjs20 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -35711,7 +35711,7 @@ var require_dist_cjs21 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider2();
     var runtimeConfig = require_runtimeConfig2();
@@ -35781,7 +35781,7 @@ var require_dist_cjs21 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -35790,7 +35790,7 @@ var require_dist_cjs21 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -37928,7 +37928,7 @@ var require_dist_cjs22 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider3();
     var runtimeConfig = require_runtimeConfig3();
@@ -38000,7 +38000,7 @@ var require_dist_cjs22 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -38009,7 +38009,7 @@ var require_dist_cjs22 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -49244,7 +49244,7 @@ var require_dist_cjs23 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider4();
     var runtimeConfig = require_runtimeConfig4();
@@ -49314,7 +49314,7 @@ var require_dist_cjs23 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -49323,7 +49323,7 @@ var require_dist_cjs23 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -51733,7 +51733,7 @@ var require_dist_cjs24 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider5();
     var runtimeConfig = require_runtimeConfig5();
@@ -51803,7 +51803,7 @@ var require_dist_cjs24 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -51812,7 +51812,7 @@ var require_dist_cjs24 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -57340,7 +57340,7 @@ var require_dist_cjs25 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider6();
     var runtimeConfig = require_runtimeConfig6();
@@ -57410,7 +57410,7 @@ var require_dist_cjs25 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -57419,7 +57419,7 @@ var require_dist_cjs25 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -75112,7 +75112,7 @@ var require_dist_cjs26 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider7();
     var runtimeConfig = require_runtimeConfig7();
@@ -75182,7 +75182,7 @@ var require_dist_cjs26 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -75191,7 +75191,7 @@ var require_dist_cjs26 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -83586,7 +83586,7 @@ var require_dist_cjs27 = __commonJS({
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var eventStreams = (init_event_streams(), __toCommonJS(event_streams_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider8();
     var runtimeConfig = require_runtimeConfig8();
@@ -83656,7 +83656,7 @@ var require_dist_cjs27 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -83666,7 +83666,7 @@ var require_dist_cjs27 = __commonJS({
         this.config = _config_9;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -88414,7 +88414,7 @@ var require_dist_cjs28 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider9();
     var runtimeConfig = require_runtimeConfig9();
@@ -88484,7 +88484,7 @@ var require_dist_cjs28 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -88493,7 +88493,7 @@ var require_dist_cjs28 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -91067,7 +91067,7 @@ var require_dist_cjs29 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider10();
     var runtimeConfig = require_runtimeConfig10();
@@ -91137,7 +91137,7 @@ var require_dist_cjs29 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -91146,7 +91146,7 @@ var require_dist_cjs29 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -97366,7 +97366,7 @@ var require_dist_cjs30 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider11();
     var runtimeConfig = require_runtimeConfig11();
@@ -97436,7 +97436,7 @@ var require_dist_cjs30 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -97445,7 +97445,7 @@ var require_dist_cjs30 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -102610,7 +102610,7 @@ var require_dist_cjs31 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider12();
     var runtimeConfig = require_runtimeConfig12();
@@ -102680,7 +102680,7 @@ var require_dist_cjs31 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -102689,7 +102689,7 @@ var require_dist_cjs31 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -106317,7 +106317,7 @@ var require_dist_cjs32 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider13();
     var runtimeConfig = require_runtimeConfig13();
@@ -106387,7 +106387,7 @@ var require_dist_cjs32 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -106396,7 +106396,7 @@ var require_dist_cjs32 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -109921,7 +109921,7 @@ var require_dist_cjs33 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider14();
     var runtimeConfig = require_runtimeConfig14();
@@ -109991,7 +109991,7 @@ var require_dist_cjs33 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -110000,7 +110000,7 @@ var require_dist_cjs33 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -121913,7 +121913,7 @@ var require_dist_cjs34 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider15();
     var runtimeConfig = require_runtimeConfig15();
@@ -121983,7 +121983,7 @@ var require_dist_cjs34 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -121992,7 +121992,7 @@ var require_dist_cjs34 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -126521,7 +126521,7 @@ var require_dist_cjs35 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider16();
     var runtimeConfig = require_runtimeConfig16();
@@ -126591,7 +126591,7 @@ var require_dist_cjs35 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -126600,7 +126600,7 @@ var require_dist_cjs35 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -137224,7 +137224,7 @@ var require_dist_cjs38 = __commonJS({
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var eventStreams = (init_event_streams(), __toCommonJS(event_streams_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider17();
     var schemas_0 = require_schemas_017();
@@ -137317,7 +137317,7 @@ var require_dist_cjs38 = __commonJS({
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
         const _config_3 = middlewareFlexibleChecksums.resolveFlexibleChecksumsConfig(_config_2);
-        const _config_4 = retry.resolveRetryConfig(_config_3);
+        const _config_4 = retry2.resolveRetryConfig(_config_3);
         const _config_5 = config.resolveRegionConfig(_config_4);
         const _config_6 = client$1.resolveHostHeaderConfig(_config_5);
         const _config_7 = endpoints.resolveEndpointConfig(_config_6);
@@ -137328,7 +137328,7 @@ var require_dist_cjs38 = __commonJS({
         this.config = _config_11;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -140366,7 +140366,7 @@ var require_dist_cjs39 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider18();
     var runtimeConfig = require_runtimeConfig18();
@@ -140436,7 +140436,7 @@ var require_dist_cjs39 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -140445,7 +140445,7 @@ var require_dist_cjs39 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -149493,14 +149493,14 @@ var require_retry_agent = __commonJS({
         this.#options = options;
       }
       dispatch(opts, handler) {
-        const retry = new RetryHandler({
+        const retry2 = new RetryHandler({
           ...opts,
           retryOptions: this.#options
         }, {
           dispatch: this.#agent.dispatch.bind(this.#agent),
           handler
         });
-        return this.#agent.dispatch(opts, retry);
+        return this.#agent.dispatch(opts, retry2);
       }
       close() {
         return this.#agent.close();
@@ -159855,8 +159855,13 @@ var actionContract = {
       required: false,
       default: "discovered-specs"
     },
+    "postman-api-key": {
+      description: "Optional service-account PMAK used to mint or re-mint a postman-access-token for telemetry enrichment (account_type). Not used for any AWS or Postman asset operation.",
+      required: false,
+      default: ""
+    },
     "postman-access-token": {
-      description: "Optional Postman service-account access token, used only to enrich anonymous telemetry with the session account_type. Not used for any AWS or Postman asset operation.",
+      description: "Optional Postman service-account access token, used only to enrich anonymous telemetry with the session account_type. When omitted, postman-api-key alone can mint one for the same purpose. Not used for any AWS or Postman asset operation.",
       required: false,
       default: ""
     }
@@ -168217,6 +168222,199 @@ async function probeSessionIdentity(baseUrl, accessToken, fetchImpl) {
   }
 }
 
+// src/lib/retry.ts
+function sleep2(delayMs) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
+function normalizeRetryOptions(options) {
+  return {
+    maxAttempts: Math.max(1, options.maxAttempts ?? 3),
+    delayMs: Math.max(0, options.delayMs ?? 2e3),
+    backoffMultiplier: Math.max(1, options.backoffMultiplier ?? 1),
+    maxDelayMs: options.maxDelayMs === void 0 ? Number.POSITIVE_INFINITY : Math.max(0, options.maxDelayMs),
+    onRetry: options.onRetry ?? (async () => void 0),
+    shouldRetry: options.shouldRetry ?? (() => true),
+    sleep: options.sleep ?? sleep2
+  };
+}
+async function retry(operation2, options = {}) {
+  const normalized = normalizeRetryOptions(options);
+  let nextDelayMs = normalized.delayMs;
+  for (let attempt = 1; attempt <= normalized.maxAttempts; attempt += 1) {
+    try {
+      return await operation2();
+    } catch (error2) {
+      const shouldRetry = attempt < normalized.maxAttempts && normalized.shouldRetry(error2, {
+        attempt,
+        maxAttempts: normalized.maxAttempts
+      });
+      if (!shouldRetry) {
+        throw error2;
+      }
+      await normalized.onRetry({
+        attempt,
+        maxAttempts: normalized.maxAttempts,
+        delayMs: nextDelayMs,
+        error: error2
+      });
+      await normalized.sleep(nextDelayMs);
+      nextDelayMs = Math.min(
+        normalized.maxDelayMs,
+        Math.round(nextDelayMs * normalized.backoffMultiplier)
+      );
+    }
+  }
+  throw new Error("Retry exhausted without returning or throwing");
+}
+
+// src/lib/postman/base-urls.ts
+var POSTMAN_ENDPOINT_PROFILES = {
+  prod: {
+    apiBaseUrl: "https://api.getpostman.com",
+    iapubBaseUrl: "https://iapub.postman.co"
+  }
+};
+
+// src/lib/postman/token-provider.ts
+var MintError = class extends Error {
+  permanent;
+  constructor(message, permanent) {
+    super(message);
+    this.name = "MintError";
+    this.permanent = permanent;
+  }
+};
+function extractAccessToken(payload2) {
+  if (!payload2 || typeof payload2 !== "object") return void 0;
+  const record = payload2;
+  const direct = record.access_token;
+  if (typeof direct === "string" && direct.trim()) return direct.trim();
+  const session = record.session;
+  if (session && typeof session === "object") {
+    const token = session.token;
+    if (typeof token === "string" && token.trim()) return token.trim();
+  }
+  return void 0;
+}
+var AccessTokenProvider = class {
+  token;
+  apiKey;
+  apiBaseUrl;
+  fetchImpl;
+  maxAttempts;
+  onToken;
+  sleep;
+  inflight;
+  constructor(options) {
+    this.token = String(options.accessToken || "").trim();
+    this.apiKey = String(options.apiKey || "").trim();
+    this.apiBaseUrl = String(
+      options.apiBaseUrl || POSTMAN_ENDPOINT_PROFILES.prod.apiBaseUrl
+    ).replace(/\/+$/, "");
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.maxAttempts = Math.max(1, options.maxAttempts ?? 2);
+    this.onToken = options.onToken;
+    this.sleep = options.sleep;
+  }
+  current() {
+    return this.token;
+  }
+  /** True when a PMAK is present, so an expired token can be re-minted. */
+  canRefresh() {
+    return Boolean(this.apiKey);
+  }
+  refresh() {
+    this.inflight ??= this.mintWithRetry().finally(() => {
+      this.inflight = void 0;
+    });
+    return this.inflight;
+  }
+  async mintWithRetry() {
+    if (!this.apiKey) {
+      throw new Error(
+        "postman: the access token expired and cannot be refreshed because no postman-api-key is present. Service-account access tokens expire after about 1 to 1.5 hours. Re-mint a fresh token (postman-resolve-service-token-action) and re-run."
+      );
+    }
+    const token = await retry(() => this.mintOnce(), {
+      maxAttempts: this.maxAttempts,
+      delayMs: 1e3,
+      backoffMultiplier: 2,
+      ...this.sleep ? { sleep: this.sleep } : {},
+      shouldRetry: (error2) => !(error2 instanceof MintError && error2.permanent)
+    });
+    this.token = token;
+    this.onToken?.(token);
+    return token;
+  }
+  async mintOnce() {
+    const response = await this.fetchImpl(`${this.apiBaseUrl}/service-account-tokens`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": this.apiKey
+      },
+      body: JSON.stringify({ apiKey: this.apiKey })
+    });
+    const body = await response.text().catch(() => "");
+    if (!response.ok) {
+      const status = response.status;
+      if (status === 401 || status === 403) {
+        throw new MintError(
+          `postman: re-mint failed because the postman-api-key was rejected (PMAK rejected, HTTP ${status}); confirm it is a valid, enabled service-account PMAK for the intended team.`,
+          true
+        );
+      }
+      if (status === 400 && body.toLowerCase().includes("service accounts not enabled")) {
+        throw new MintError(
+          "postman: re-mint failed because service accounts are not enabled for this team; enable them in Team Settings or use a team where they are.",
+          true
+        );
+      }
+      throw new MintError(`postman: re-mint failed (service-account-tokens HTTP ${status}).`, false);
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(body);
+    } catch {
+      parsed = void 0;
+    }
+    const token = extractAccessToken(parsed);
+    if (!token) {
+      throw new MintError("postman: re-mint succeeded but no access token was returned.", false);
+    }
+    return token;
+  }
+};
+
+// src/lib/postman/telemetry-credentials.ts
+async function prepareTelemetryCredentials(options) {
+  const apiKey = String(options.postmanApiKey || "").trim();
+  const accessToken = String(options.postmanAccessToken || "").trim();
+  if (!apiKey && !accessToken) {
+    return {};
+  }
+  const provider = new AccessTokenProvider({
+    accessToken,
+    apiKey,
+    apiBaseUrl: options.apiBaseUrl || POSTMAN_ENDPOINT_PROFILES.prod.apiBaseUrl,
+    onToken: options.onToken,
+    ...options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}
+  });
+  if (!accessToken && apiKey && provider.canRefresh()) {
+    try {
+      await provider.refresh();
+    } catch {
+    }
+  }
+  const accountType = await resolveTelemetryAccountType(provider.current(), options.fetchImpl);
+  return {
+    provider,
+    ...accountType ? { accountType } : {}
+  };
+}
+
 // node_modules/@postman-cse/automation-telemetry-core/dist/ci-context.js
 function norm(value) {
   const trimmed = (value ?? "").trim();
@@ -168645,7 +168843,9 @@ function parseCliArgs(argv, env2 = process.env) {
     "preflight-permission-probe",
     "request-timeout-ms",
     "max-attempts",
-    "include-v2"
+    "include-v2",
+    "postman-api-key",
+    "postman-access-token"
   ];
   const inputEnv = { ...env2 };
   for (const name of inputNames) {
@@ -168705,9 +168905,10 @@ async function runCli(argv = process.argv.slice(2)) {
   const reporter = new ConsoleReporter();
   const telemetry = createTelemetryContext({ action: "postman-aws-spec-discovery-action", logger: reporter });
   telemetry.setTeamId(config.inputEnv.POSTMAN_TEAM_ID ?? process.env.POSTMAN_TEAM_ID);
-  const accountType = await resolveTelemetryAccountType(
-    config.inputEnv.INPUT_POSTMAN_ACCESS_TOKEN ?? process.env.POSTMAN_ACCESS_TOKEN
-  );
+  const { accountType } = await prepareTelemetryCredentials({
+    postmanApiKey: config.inputEnv.INPUT_POSTMAN_API_KEY ?? process.env.POSTMAN_API_KEY,
+    postmanAccessToken: config.inputEnv.INPUT_POSTMAN_ACCESS_TOKEN ?? process.env.POSTMAN_ACCESS_TOKEN
+  });
   try {
     const result = await execute(inputs, {
       core: reporter,

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -161545,6 +161545,11 @@ var actionContract = {
       description: "Directory under the repository root where generated specs are written.",
       required: false,
       default: "discovered-specs"
+    },
+    "postman-access-token": {
+      description: "Optional Postman service-account access token, used only to enrich anonymous telemetry with the session account_type. Not used for any AWS or Postman asset operation.",
+      required: false,
+      default: ""
     }
   },
   outputs: {
@@ -170665,6 +170670,93 @@ async function execute(inputs, dependencies) {
   };
 }
 
+// src/lib/postman/credential-identity.ts
+var sessionPath = "/api/sessions/current";
+var DEFAULT_IAPUB_BASE_URL = "https://iapub.postman.co";
+var sessionMemo = /* @__PURE__ */ new Map();
+var memoizedSessionIdentity;
+function asRecord(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return void 0;
+  }
+  return value;
+}
+function coerceId(raw) {
+  return raw ? String(raw) : void 0;
+}
+function coerceText(raw) {
+  if (typeof raw !== "string") {
+    return void 0;
+  }
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : void 0;
+}
+function normalizeBaseUrl(raw) {
+  return String(raw || "").replace(/\/+$/, "");
+}
+async function resolveSessionIdentity(opts) {
+  const accessToken = String(opts.accessToken || "").trim();
+  if (!accessToken) {
+    return void 0;
+  }
+  const baseUrl = normalizeBaseUrl(opts.iapubBaseUrl);
+  const memoKey = `${baseUrl}::${accessToken}`;
+  let pending = sessionMemo.get(memoKey);
+  if (!pending) {
+    pending = probeSessionIdentity(baseUrl, accessToken, opts.fetchImpl ?? fetch);
+    sessionMemo.set(memoKey, pending);
+  }
+  return pending;
+}
+async function resolveTelemetryAccountType(accessToken, fetchImpl) {
+  const token = String(accessToken || "").trim();
+  if (!token) {
+    return void 0;
+  }
+  const identity = await resolveSessionIdentity({
+    iapubBaseUrl: DEFAULT_IAPUB_BASE_URL,
+    accessToken: token,
+    ...fetchImpl ? { fetchImpl } : {}
+  }).catch(() => void 0);
+  return identity?.consumerType;
+}
+async function probeSessionIdentity(baseUrl, accessToken, fetchImpl) {
+  try {
+    const response = await fetchImpl(`${baseUrl}${sessionPath}`, {
+      method: "GET",
+      headers: { "x-access-token": accessToken }
+    });
+    if (!response.ok) {
+      return void 0;
+    }
+    const payload2 = asRecord(await response.json());
+    if (!payload2) {
+      return void 0;
+    }
+    const root5 = asRecord(payload2.session) ?? payload2;
+    const identity = asRecord(root5.identity);
+    const data2 = asRecord(root5.data);
+    const user = asRecord(data2?.user);
+    const roleEntries = Array.isArray(user?.roles) ? user.roles.map((entry) => coerceText(entry) ?? coerceId(entry)).filter((entry) => Boolean(entry)) : [];
+    const singleRole = coerceText(user?.role);
+    const roles = roleEntries.length > 0 ? roleEntries : singleRole ? [singleRole] : void 0;
+    const resolved = {
+      source: "iapub/sessions",
+      userId: coerceId(identity?.user) ?? coerceId(user?.id),
+      fullName: coerceText(user?.fullName) ?? coerceText(user?.name) ?? coerceText(user?.username),
+      teamId: coerceId(identity?.team),
+      teamName: coerceText(user?.teamName),
+      teamDomain: coerceText(identity?.domain),
+      ...roles ? { roles } : {},
+      consumerType: coerceText(root5.consumerType) ?? coerceText(data2?.consumerType) ?? coerceText(user?.consumerType)
+    };
+    memoizedSessionIdentity = resolved;
+    return resolved;
+  } catch {
+    return void 0;
+  }
+}
+
 // node_modules/@postman-cse/automation-telemetry-core/dist/ci-context.js
 function norm(value) {
   const trimmed = (value ?? "").trim();
@@ -171045,11 +171137,14 @@ function createTelemetryContext(options) {
 async function runAction(actionCore = core_exports, dependencies = {}) {
   const telemetry = createTelemetryContext({ action: "postman-aws-spec-discovery-action", logger: actionCore });
   telemetry.setTeamId(process.env.POSTMAN_TEAM_ID);
+  const accountType = await resolveTelemetryAccountType(getInput2("postman-access-token"));
   try {
     const result = await runActionInner(actionCore, dependencies);
+    telemetry.setAccountType(accountType);
     telemetry.emitCompletion("success");
     return result;
   } catch (error3) {
+    telemetry.setAccountType(accountType);
     telemetry.emitCompletion("failure");
     throw error3;
   }

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -9195,14 +9195,14 @@ var require_retry_agent = __commonJS({
         this.#options = options;
       }
       dispatch(opts, handler) {
-        const retry = new RetryHandler({
+        const retry2 = new RetryHandler({
           ...opts,
           retryOptions: this.#options
         }, {
           dispatch: this.#agent.dispatch.bind(this.#agent),
           handler
         });
-        return this.#agent.dispatch(opts, retry);
+        return this.#agent.dispatch(opts, retry2);
       }
       close() {
         return this.#agent.close();
@@ -33482,7 +33482,7 @@ var require_dist_cjs8 = __commonJS({
         req.end();
       });
     }
-    var retry = (toRetry, maxRetries) => {
+    var retry2 = (toRetry, maxRetries) => {
       let promise = toRetry();
       for (let i5 = 0; i5 < maxRetries; i5++) {
         promise = promise.catch(toRetry);
@@ -33494,7 +33494,7 @@ var require_dist_cjs8 = __commonJS({
     var ENV_CMDS_AUTH_TOKEN = "AWS_CONTAINER_AUTHORIZATION_TOKEN";
     var fromContainerMetadata = (init = {}) => {
       const { timeout, maxRetries } = providerConfigFromInit(init);
-      return () => retry(async () => {
+      return () => retry2(async () => {
         const requestOptions = await getCmdsUri({ logger: init.logger });
         const credsResponse = JSON.parse(await requestFromEcsImds(timeout, requestOptions));
         if (!isImdsCredentials(credsResponse)) {
@@ -33686,7 +33686,7 @@ For more information, please visit: ` + STATIC_STABILITY_DOC_URL);
             throw new InstanceMetadataV1FallbackError(`AWS EC2 Metadata v1 fallback has been blocked by AWS SDK configuration in the following: [${causes.join(", ")}].`);
           }
         }
-        const imdsProfile = (await retry(async () => {
+        const imdsProfile = (await retry2(async () => {
           let profile2;
           try {
             profile2 = await getProfile(options);
@@ -33698,7 +33698,7 @@ For more information, please visit: ` + STATIC_STABILITY_DOC_URL);
           }
           return profile2;
         }, maxRetries2)).trim();
-        return retry(async () => {
+        return retry2(async () => {
           let creds;
           try {
             creds = await getCredentialsFromProfile(imdsProfile, options, init);
@@ -48831,7 +48831,7 @@ var require_dist_cjs20 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider();
     var runtimeConfig = require_runtimeConfig();
@@ -48901,7 +48901,7 @@ var require_dist_cjs20 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -48910,7 +48910,7 @@ var require_dist_cjs20 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -54351,7 +54351,7 @@ var require_dist_cjs21 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider2();
     var runtimeConfig = require_runtimeConfig2();
@@ -54421,7 +54421,7 @@ var require_dist_cjs21 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -54430,7 +54430,7 @@ var require_dist_cjs21 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -56568,7 +56568,7 @@ var require_dist_cjs22 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider3();
     var runtimeConfig = require_runtimeConfig3();
@@ -56640,7 +56640,7 @@ var require_dist_cjs22 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -56649,7 +56649,7 @@ var require_dist_cjs22 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -67884,7 +67884,7 @@ var require_dist_cjs23 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider4();
     var runtimeConfig = require_runtimeConfig4();
@@ -67954,7 +67954,7 @@ var require_dist_cjs23 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -67963,7 +67963,7 @@ var require_dist_cjs23 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -70373,7 +70373,7 @@ var require_dist_cjs24 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider5();
     var runtimeConfig = require_runtimeConfig5();
@@ -70443,7 +70443,7 @@ var require_dist_cjs24 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -70452,7 +70452,7 @@ var require_dist_cjs24 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -75980,7 +75980,7 @@ var require_dist_cjs25 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider6();
     var runtimeConfig = require_runtimeConfig6();
@@ -76050,7 +76050,7 @@ var require_dist_cjs25 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -76059,7 +76059,7 @@ var require_dist_cjs25 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -93752,7 +93752,7 @@ var require_dist_cjs26 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider7();
     var runtimeConfig = require_runtimeConfig7();
@@ -93822,7 +93822,7 @@ var require_dist_cjs26 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -93831,7 +93831,7 @@ var require_dist_cjs26 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -102226,7 +102226,7 @@ var require_dist_cjs27 = __commonJS({
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var eventStreams = (init_event_streams(), __toCommonJS(event_streams_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider8();
     var runtimeConfig = require_runtimeConfig8();
@@ -102296,7 +102296,7 @@ var require_dist_cjs27 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -102306,7 +102306,7 @@ var require_dist_cjs27 = __commonJS({
         this.config = _config_9;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -107054,7 +107054,7 @@ var require_dist_cjs28 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider9();
     var runtimeConfig = require_runtimeConfig9();
@@ -107124,7 +107124,7 @@ var require_dist_cjs28 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -107133,7 +107133,7 @@ var require_dist_cjs28 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -109707,7 +109707,7 @@ var require_dist_cjs29 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider10();
     var runtimeConfig = require_runtimeConfig10();
@@ -109777,7 +109777,7 @@ var require_dist_cjs29 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -109786,7 +109786,7 @@ var require_dist_cjs29 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -116006,7 +116006,7 @@ var require_dist_cjs30 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider11();
     var runtimeConfig = require_runtimeConfig11();
@@ -116076,7 +116076,7 @@ var require_dist_cjs30 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -116085,7 +116085,7 @@ var require_dist_cjs30 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -121250,7 +121250,7 @@ var require_dist_cjs31 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider12();
     var runtimeConfig = require_runtimeConfig12();
@@ -121320,7 +121320,7 @@ var require_dist_cjs31 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -121329,7 +121329,7 @@ var require_dist_cjs31 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -124957,7 +124957,7 @@ var require_dist_cjs32 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider13();
     var runtimeConfig = require_runtimeConfig13();
@@ -125027,7 +125027,7 @@ var require_dist_cjs32 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -125036,7 +125036,7 @@ var require_dist_cjs32 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -128561,7 +128561,7 @@ var require_dist_cjs33 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider14();
     var runtimeConfig = require_runtimeConfig14();
@@ -128631,7 +128631,7 @@ var require_dist_cjs33 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -128640,7 +128640,7 @@ var require_dist_cjs33 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -140553,7 +140553,7 @@ var require_dist_cjs34 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider15();
     var runtimeConfig = require_runtimeConfig15();
@@ -140623,7 +140623,7 @@ var require_dist_cjs34 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -140632,7 +140632,7 @@ var require_dist_cjs34 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -145161,7 +145161,7 @@ var require_dist_cjs35 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider16();
     var runtimeConfig = require_runtimeConfig16();
@@ -145231,7 +145231,7 @@ var require_dist_cjs35 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -145240,7 +145240,7 @@ var require_dist_cjs35 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -155864,7 +155864,7 @@ var require_dist_cjs38 = __commonJS({
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var eventStreams = (init_event_streams(), __toCommonJS(event_streams_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider17();
     var schemas_0 = require_schemas_017();
@@ -155957,7 +155957,7 @@ var require_dist_cjs38 = __commonJS({
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
         const _config_3 = middlewareFlexibleChecksums.resolveFlexibleChecksumsConfig(_config_2);
-        const _config_4 = retry.resolveRetryConfig(_config_3);
+        const _config_4 = retry2.resolveRetryConfig(_config_3);
         const _config_5 = config.resolveRegionConfig(_config_4);
         const _config_6 = client$1.resolveHostHeaderConfig(_config_5);
         const _config_7 = endpoints.resolveEndpointConfig(_config_6);
@@ -155968,7 +155968,7 @@ var require_dist_cjs38 = __commonJS({
         this.config = _config_11;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -159006,7 +159006,7 @@ var require_dist_cjs39 = __commonJS({
     var config = (init_config2(), __toCommonJS(config_exports));
     var endpoints = (init_endpoints(), __toCommonJS(endpoints_exports));
     var protocols = (init_protocols(), __toCommonJS(protocols_exports));
-    var retry = (init_retry2(), __toCommonJS(retry_exports));
+    var retry2 = (init_retry2(), __toCommonJS(retry_exports));
     var schema = (init_schema(), __toCommonJS(schema_exports));
     var httpAuthSchemeProvider = require_httpAuthSchemeProvider18();
     var runtimeConfig = require_runtimeConfig18();
@@ -159076,7 +159076,7 @@ var require_dist_cjs39 = __commonJS({
         this.initConfig = _config_0;
         const _config_1 = resolveClientEndpointParameters5(_config_0);
         const _config_2 = client$1.resolveUserAgentConfig(_config_1);
-        const _config_3 = retry.resolveRetryConfig(_config_2);
+        const _config_3 = retry2.resolveRetryConfig(_config_2);
         const _config_4 = config.resolveRegionConfig(_config_3);
         const _config_5 = client$1.resolveHostHeaderConfig(_config_4);
         const _config_6 = endpoints.resolveEndpointConfig(_config_5);
@@ -159085,7 +159085,7 @@ var require_dist_cjs39 = __commonJS({
         this.config = _config_8;
         this.middlewareStack.use(schema.getSchemaSerdePlugin(this.config));
         this.middlewareStack.use(client$1.getUserAgentPlugin(this.config));
-        this.middlewareStack.use(retry.getRetryPlugin(this.config));
+        this.middlewareStack.use(retry2.getRetryPlugin(this.config));
         this.middlewareStack.use(protocols.getContentLengthPlugin(this.config));
         this.middlewareStack.use(client$1.getHostHeaderPlugin(this.config));
         this.middlewareStack.use(client$1.getLoggerPlugin(this.config));
@@ -161546,8 +161546,13 @@ var actionContract = {
       required: false,
       default: "discovered-specs"
     },
+    "postman-api-key": {
+      description: "Optional service-account PMAK used to mint or re-mint a postman-access-token for telemetry enrichment (account_type). Not used for any AWS or Postman asset operation.",
+      required: false,
+      default: ""
+    },
     "postman-access-token": {
-      description: "Optional Postman service-account access token, used only to enrich anonymous telemetry with the session account_type. Not used for any AWS or Postman asset operation.",
+      description: "Optional Postman service-account access token, used only to enrich anonymous telemetry with the session account_type. When omitted, postman-api-key alone can mint one for the same purpose. Not used for any AWS or Postman asset operation.",
       required: false,
       default: ""
     }
@@ -170757,6 +170762,199 @@ async function probeSessionIdentity(baseUrl, accessToken, fetchImpl) {
   }
 }
 
+// src/lib/retry.ts
+function sleep2(delayMs) {
+  return new Promise((resolve2) => {
+    setTimeout(resolve2, delayMs);
+  });
+}
+function normalizeRetryOptions(options) {
+  return {
+    maxAttempts: Math.max(1, options.maxAttempts ?? 3),
+    delayMs: Math.max(0, options.delayMs ?? 2e3),
+    backoffMultiplier: Math.max(1, options.backoffMultiplier ?? 1),
+    maxDelayMs: options.maxDelayMs === void 0 ? Number.POSITIVE_INFINITY : Math.max(0, options.maxDelayMs),
+    onRetry: options.onRetry ?? (async () => void 0),
+    shouldRetry: options.shouldRetry ?? (() => true),
+    sleep: options.sleep ?? sleep2
+  };
+}
+async function retry(operation2, options = {}) {
+  const normalized = normalizeRetryOptions(options);
+  let nextDelayMs = normalized.delayMs;
+  for (let attempt = 1; attempt <= normalized.maxAttempts; attempt += 1) {
+    try {
+      return await operation2();
+    } catch (error3) {
+      const shouldRetry = attempt < normalized.maxAttempts && normalized.shouldRetry(error3, {
+        attempt,
+        maxAttempts: normalized.maxAttempts
+      });
+      if (!shouldRetry) {
+        throw error3;
+      }
+      await normalized.onRetry({
+        attempt,
+        maxAttempts: normalized.maxAttempts,
+        delayMs: nextDelayMs,
+        error: error3
+      });
+      await normalized.sleep(nextDelayMs);
+      nextDelayMs = Math.min(
+        normalized.maxDelayMs,
+        Math.round(nextDelayMs * normalized.backoffMultiplier)
+      );
+    }
+  }
+  throw new Error("Retry exhausted without returning or throwing");
+}
+
+// src/lib/postman/base-urls.ts
+var POSTMAN_ENDPOINT_PROFILES = {
+  prod: {
+    apiBaseUrl: "https://api.getpostman.com",
+    iapubBaseUrl: "https://iapub.postman.co"
+  }
+};
+
+// src/lib/postman/token-provider.ts
+var MintError = class extends Error {
+  permanent;
+  constructor(message, permanent) {
+    super(message);
+    this.name = "MintError";
+    this.permanent = permanent;
+  }
+};
+function extractAccessToken(payload2) {
+  if (!payload2 || typeof payload2 !== "object") return void 0;
+  const record = payload2;
+  const direct = record.access_token;
+  if (typeof direct === "string" && direct.trim()) return direct.trim();
+  const session = record.session;
+  if (session && typeof session === "object") {
+    const token = session.token;
+    if (typeof token === "string" && token.trim()) return token.trim();
+  }
+  return void 0;
+}
+var AccessTokenProvider = class {
+  token;
+  apiKey;
+  apiBaseUrl;
+  fetchImpl;
+  maxAttempts;
+  onToken;
+  sleep;
+  inflight;
+  constructor(options) {
+    this.token = String(options.accessToken || "").trim();
+    this.apiKey = String(options.apiKey || "").trim();
+    this.apiBaseUrl = String(
+      options.apiBaseUrl || POSTMAN_ENDPOINT_PROFILES.prod.apiBaseUrl
+    ).replace(/\/+$/, "");
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.maxAttempts = Math.max(1, options.maxAttempts ?? 2);
+    this.onToken = options.onToken;
+    this.sleep = options.sleep;
+  }
+  current() {
+    return this.token;
+  }
+  /** True when a PMAK is present, so an expired token can be re-minted. */
+  canRefresh() {
+    return Boolean(this.apiKey);
+  }
+  refresh() {
+    this.inflight ??= this.mintWithRetry().finally(() => {
+      this.inflight = void 0;
+    });
+    return this.inflight;
+  }
+  async mintWithRetry() {
+    if (!this.apiKey) {
+      throw new Error(
+        "postman: the access token expired and cannot be refreshed because no postman-api-key is present. Service-account access tokens expire after about 1 to 1.5 hours. Re-mint a fresh token (postman-resolve-service-token-action) and re-run."
+      );
+    }
+    const token = await retry(() => this.mintOnce(), {
+      maxAttempts: this.maxAttempts,
+      delayMs: 1e3,
+      backoffMultiplier: 2,
+      ...this.sleep ? { sleep: this.sleep } : {},
+      shouldRetry: (error3) => !(error3 instanceof MintError && error3.permanent)
+    });
+    this.token = token;
+    this.onToken?.(token);
+    return token;
+  }
+  async mintOnce() {
+    const response = await this.fetchImpl(`${this.apiBaseUrl}/service-account-tokens`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": this.apiKey
+      },
+      body: JSON.stringify({ apiKey: this.apiKey })
+    });
+    const body = await response.text().catch(() => "");
+    if (!response.ok) {
+      const status = response.status;
+      if (status === 401 || status === 403) {
+        throw new MintError(
+          `postman: re-mint failed because the postman-api-key was rejected (PMAK rejected, HTTP ${status}); confirm it is a valid, enabled service-account PMAK for the intended team.`,
+          true
+        );
+      }
+      if (status === 400 && body.toLowerCase().includes("service accounts not enabled")) {
+        throw new MintError(
+          "postman: re-mint failed because service accounts are not enabled for this team; enable them in Team Settings or use a team where they are.",
+          true
+        );
+      }
+      throw new MintError(`postman: re-mint failed (service-account-tokens HTTP ${status}).`, false);
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(body);
+    } catch {
+      parsed = void 0;
+    }
+    const token = extractAccessToken(parsed);
+    if (!token) {
+      throw new MintError("postman: re-mint succeeded but no access token was returned.", false);
+    }
+    return token;
+  }
+};
+
+// src/lib/postman/telemetry-credentials.ts
+async function prepareTelemetryCredentials(options) {
+  const apiKey = String(options.postmanApiKey || "").trim();
+  const accessToken = String(options.postmanAccessToken || "").trim();
+  if (!apiKey && !accessToken) {
+    return {};
+  }
+  const provider = new AccessTokenProvider({
+    accessToken,
+    apiKey,
+    apiBaseUrl: options.apiBaseUrl || POSTMAN_ENDPOINT_PROFILES.prod.apiBaseUrl,
+    onToken: options.onToken,
+    ...options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}
+  });
+  if (!accessToken && apiKey && provider.canRefresh()) {
+    try {
+      await provider.refresh();
+    } catch {
+    }
+  }
+  const accountType = await resolveTelemetryAccountType(provider.current(), options.fetchImpl);
+  return {
+    provider,
+    ...accountType ? { accountType } : {}
+  };
+}
+
 // node_modules/@postman-cse/automation-telemetry-core/dist/ci-context.js
 function norm(value) {
   const trimmed = (value ?? "").trim();
@@ -171137,7 +171335,19 @@ function createTelemetryContext(options) {
 async function runAction(actionCore = core_exports, dependencies = {}) {
   const telemetry = createTelemetryContext({ action: "postman-aws-spec-discovery-action", logger: actionCore });
   telemetry.setTeamId(process.env.POSTMAN_TEAM_ID);
-  const accountType = await resolveTelemetryAccountType(getInput2("postman-access-token"));
+  const postmanApiKey = getInput2("postman-api-key");
+  const postmanAccessToken = getInput2("postman-access-token");
+  if (postmanApiKey) {
+    actionCore.setSecret?.(postmanApiKey);
+  }
+  if (postmanAccessToken) {
+    actionCore.setSecret?.(postmanAccessToken);
+  }
+  const { accountType } = await prepareTelemetryCredentials({
+    postmanApiKey,
+    postmanAccessToken,
+    onToken: (token) => actionCore.setSecret?.(token)
+  });
   try {
     const result = await runActionInner(actionCore, dependencies);
     telemetry.setAccountType(accountType);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { AwsApiGatewaySdkClient } from './lib/aws/client.js';
 import { formatUserSafeError, sanitizeLogMessage } from './lib/logging/sanitize.js';
 import { defaultWriteSpecFile, execute, resolveInputs, type ReporterLike } from './runtime.js';
+import { resolveTelemetryAccountType } from './lib/postman/credential-identity.js';
 import { createTelemetryContext } from '@postman-cse/automation-telemetry-core';
 
 interface CliConfig {
@@ -136,6 +137,11 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<vo
   const reporter = new ConsoleReporter();
   const telemetry = createTelemetryContext({ action: 'postman-aws-spec-discovery-action', logger: reporter });
   telemetry.setTeamId(config.inputEnv.POSTMAN_TEAM_ID ?? process.env.POSTMAN_TEAM_ID);
+  // Optional access-token telemetry enrichment (D1): resolve account_type once,
+  // best-effort, and set it before either completion emit.
+  const accountType = await resolveTelemetryAccountType(
+    config.inputEnv.INPUT_POSTMAN_ACCESS_TOKEN ?? process.env.POSTMAN_ACCESS_TOKEN
+  );
   try {
     const result = await execute(inputs, {
       core: reporter,
@@ -150,8 +156,10 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<vo
     await writeOptionalFile(config.dotenvPath, toDotenv(result.outputs));
 
     process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    telemetry.setAccountType(accountType);
     telemetry.emitCompletion('success');
   } catch (error) {
+    telemetry.setAccountType(accountType);
     telemetry.emitCompletion('failure');
     throw error;
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { AwsApiGatewaySdkClient } from './lib/aws/client.js';
 import { formatUserSafeError, sanitizeLogMessage } from './lib/logging/sanitize.js';
 import { defaultWriteSpecFile, execute, resolveInputs, type ReporterLike } from './runtime.js';
-import { resolveTelemetryAccountType } from './lib/postman/credential-identity.js';
+import { prepareTelemetryCredentials } from './lib/postman/telemetry-credentials.js';
 import { createTelemetryContext } from '@postman-cse/automation-telemetry-core';
 
 interface CliConfig {
@@ -69,7 +69,9 @@ export function parseCliArgs(argv: string[], env: NodeJS.ProcessEnv = process.en
     'preflight-permission-probe',
     'request-timeout-ms',
     'max-attempts',
-    'include-v2'
+    'include-v2',
+    'postman-api-key',
+    'postman-access-token'
   ];
 
   const inputEnv: NodeJS.ProcessEnv = { ...env };
@@ -137,11 +139,12 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<vo
   const reporter = new ConsoleReporter();
   const telemetry = createTelemetryContext({ action: 'postman-aws-spec-discovery-action', logger: reporter });
   telemetry.setTeamId(config.inputEnv.POSTMAN_TEAM_ID ?? process.env.POSTMAN_TEAM_ID);
-  // Optional access-token telemetry enrichment (D1): resolve account_type once,
-  // best-effort, and set it before either completion emit.
-  const accountType = await resolveTelemetryAccountType(
-    config.inputEnv.INPUT_POSTMAN_ACCESS_TOKEN ?? process.env.POSTMAN_ACCESS_TOKEN
-  );
+  // Optional telemetry enrichment (D1): mint/re-mint access token when PMAK is
+  // present, resolve account_type once, best-effort, before either completion emit.
+  const { accountType } = await prepareTelemetryCredentials({
+    postmanApiKey: config.inputEnv.INPUT_POSTMAN_API_KEY ?? process.env.POSTMAN_API_KEY,
+    postmanAccessToken: config.inputEnv.INPUT_POSTMAN_ACCESS_TOKEN ?? process.env.POSTMAN_ACCESS_TOKEN
+  });
   try {
     const result = await execute(inputs, {
       core: reporter,

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -150,6 +150,12 @@ export const actionContract: AwsSpecDiscoveryActionContract = {
       description: 'Directory under the repository root where generated specs are written.',
       required: false,
       default: 'discovered-specs'
+    },
+    'postman-access-token': {
+      description:
+        'Optional Postman service-account access token, used only to enrich anonymous telemetry with the session account_type. Not used for any AWS or Postman asset operation.',
+      required: false,
+      default: ''
     }
   },
   outputs: {

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -151,9 +151,15 @@ export const actionContract: AwsSpecDiscoveryActionContract = {
       required: false,
       default: 'discovered-specs'
     },
+    'postman-api-key': {
+      description:
+        'Optional service-account PMAK used to mint or re-mint a postman-access-token for telemetry enrichment (account_type). Not used for any AWS or Postman asset operation.',
+      required: false,
+      default: ''
+    },
     'postman-access-token': {
       description:
-        'Optional Postman service-account access token, used only to enrich anonymous telemetry with the session account_type. Not used for any AWS or Postman asset operation.',
+        'Optional Postman service-account access token, used only to enrich anonymous telemetry with the session account_type. When omitted, postman-api-key alone can mint one for the same purpose. Not used for any AWS or Postman asset operation.',
       required: false,
       default: ''
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,10 +9,12 @@ import { ApiGatewayProvider } from './lib/providers/api-gateway.js';
 import {
   defaultWriteSpecFile,
   execute,
+  getInput,
   readActionInputs,
   type InputReaderLike,
   type ReporterLike
 } from './runtime.js';
+import { resolveTelemetryAccountType } from './lib/postman/credential-identity.js';
 import { createTelemetryContext } from '@postman-cse/automation-telemetry-core';
 
 export interface CoreLike extends InputReaderLike, ReporterLike {
@@ -32,11 +34,16 @@ export async function runAction(
 ): Promise<DiscoveredService[]> {
   const telemetry = createTelemetryContext({ action: 'postman-aws-spec-discovery-action', logger: actionCore });
   telemetry.setTeamId(process.env.POSTMAN_TEAM_ID);
+  // Optional access-token telemetry enrichment (D1): resolve account_type once,
+  // best-effort, and set it before either completion emit.
+  const accountType = await resolveTelemetryAccountType(getInput('postman-access-token'));
   try {
     const result = await runActionInner(actionCore, dependencies);
+    telemetry.setAccountType(accountType);
     telemetry.emitCompletion('success');
     return result;
   } catch (error) {
+    telemetry.setAccountType(accountType);
     telemetry.emitCompletion('failure');
     throw error;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,12 +14,13 @@ import {
   type InputReaderLike,
   type ReporterLike
 } from './runtime.js';
-import { resolveTelemetryAccountType } from './lib/postman/credential-identity.js';
+import { prepareTelemetryCredentials } from './lib/postman/telemetry-credentials.js';
 import { createTelemetryContext } from '@postman-cse/automation-telemetry-core';
 
 export interface CoreLike extends InputReaderLike, ReporterLike {
   setOutput(name: string, value: string): void;
   setFailed(message: string): void;
+  setSecret?(value: string): void;
 }
 
 export interface GitHubActionDependencies {
@@ -34,9 +35,21 @@ export async function runAction(
 ): Promise<DiscoveredService[]> {
   const telemetry = createTelemetryContext({ action: 'postman-aws-spec-discovery-action', logger: actionCore });
   telemetry.setTeamId(process.env.POSTMAN_TEAM_ID);
-  // Optional access-token telemetry enrichment (D1): resolve account_type once,
-  // best-effort, and set it before either completion emit.
-  const accountType = await resolveTelemetryAccountType(getInput('postman-access-token'));
+  const postmanApiKey = getInput('postman-api-key');
+  const postmanAccessToken = getInput('postman-access-token');
+  if (postmanApiKey) {
+    actionCore.setSecret?.(postmanApiKey);
+  }
+  if (postmanAccessToken) {
+    actionCore.setSecret?.(postmanAccessToken);
+  }
+  // Optional telemetry enrichment (D1): mint/re-mint access token when PMAK is
+  // present, resolve account_type once, best-effort, before either completion emit.
+  const { accountType } = await prepareTelemetryCredentials({
+    postmanApiKey,
+    postmanAccessToken,
+    onToken: (token) => actionCore.setSecret?.(token)
+  });
   try {
     const result = await runActionInner(actionCore, dependencies);
     telemetry.setAccountType(accountType);

--- a/src/lib/postman/base-urls.ts
+++ b/src/lib/postman/base-urls.ts
@@ -1,0 +1,11 @@
+export interface PostmanEndpointProfile {
+  apiBaseUrl: string;
+  iapubBaseUrl: string;
+}
+
+export const POSTMAN_ENDPOINT_PROFILES: Record<'prod', PostmanEndpointProfile> = {
+  prod: {
+    apiBaseUrl: 'https://api.getpostman.com',
+    iapubBaseUrl: 'https://iapub.postman.co'
+  }
+};

--- a/src/lib/postman/credential-identity.ts
+++ b/src/lib/postman/credential-identity.ts
@@ -1,0 +1,154 @@
+// Session-identity subset copied from the shared credential-identity foundation
+// (postman-repo-sync-action/src/lib/postman/credential-identity.ts). This action
+// makes no Postman asset calls; it resolves the access-token -> iapub session
+// only so telemetry can emit `account_type` from the resolved `consumerType`
+// (D1: an optional postman-access-token input used for telemetry enrichment).
+
+export interface CredentialIdentity {
+  source: 'pmak/me' | 'iapub/sessions';
+  userId?: string;
+  fullName?: string;
+  teamId?: string;
+  teamName?: string;
+  teamDomain?: string;
+  roles?: string[];
+  consumerType?: string;
+}
+
+export interface ResolveSessionIdentityOptions {
+  iapubBaseUrl: string;
+  accessToken: string;
+  fetchImpl?: typeof fetch;
+}
+
+const sessionPath = '/api/sessions/current';
+const DEFAULT_IAPUB_BASE_URL = 'https://iapub.postman.co';
+
+type JsonRecord = Record<string, unknown>;
+
+const sessionMemo = new Map<string, Promise<CredentialIdentity | undefined>>();
+let memoizedSessionIdentity: CredentialIdentity | undefined;
+
+/** Test-only: clears the in-process identity memo so cases cannot bleed into each other. */
+export function __resetIdentityMemo(): void {
+  sessionMemo.clear();
+  memoizedSessionIdentity = undefined;
+}
+
+/** Last session identity resolved in this process, consumed for telemetry account_type. */
+export function getMemoizedSessionIdentity(): CredentialIdentity | undefined {
+  return memoizedSessionIdentity;
+}
+
+function asRecord(value: unknown): JsonRecord | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as JsonRecord;
+}
+
+function coerceId(raw: unknown): string | undefined {
+  return raw ? String(raw) : undefined;
+}
+
+function coerceText(raw: unknown): string | undefined {
+  if (typeof raw !== 'string') {
+    return undefined;
+  }
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function normalizeBaseUrl(raw: string): string {
+  return String(raw || '').replace(/\/+$/, '');
+}
+
+export async function resolveSessionIdentity(
+  opts: ResolveSessionIdentityOptions
+): Promise<CredentialIdentity | undefined> {
+  const accessToken = String(opts.accessToken || '').trim();
+  if (!accessToken) {
+    return undefined;
+  }
+  const baseUrl = normalizeBaseUrl(opts.iapubBaseUrl);
+  const memoKey = `${baseUrl}::${accessToken}`;
+  let pending = sessionMemo.get(memoKey);
+  if (!pending) {
+    pending = probeSessionIdentity(baseUrl, accessToken, opts.fetchImpl ?? fetch);
+    sessionMemo.set(memoKey, pending);
+  }
+  return pending;
+}
+
+/**
+ * Resolve telemetry `account_type` (session consumerType) from an optional
+ * access token. Best-effort: any failure yields undefined so telemetry stays
+ * `unknown` rather than breaking discovery.
+ */
+export async function resolveTelemetryAccountType(
+  accessToken: string | undefined,
+  fetchImpl?: typeof fetch
+): Promise<string | undefined> {
+  const token = String(accessToken || '').trim();
+  if (!token) {
+    return undefined;
+  }
+  const identity = await resolveSessionIdentity({
+    iapubBaseUrl: DEFAULT_IAPUB_BASE_URL,
+    accessToken: token,
+    ...(fetchImpl ? { fetchImpl } : {})
+  }).catch(() => undefined);
+  return identity?.consumerType;
+}
+
+async function probeSessionIdentity(
+  baseUrl: string,
+  accessToken: string,
+  fetchImpl: typeof fetch
+): Promise<CredentialIdentity | undefined> {
+  try {
+    const response = await fetchImpl(`${baseUrl}${sessionPath}`, {
+      method: 'GET',
+      headers: { 'x-access-token': accessToken }
+    });
+    if (!response.ok) {
+      return undefined;
+    }
+    const payload = asRecord(await response.json());
+    if (!payload) {
+      return undefined;
+    }
+    // iapub wraps the live session under `session`; tolerate an unwrapped shape too.
+    // Whitelisted extraction only; the raw session body (incl. session.token) is discarded.
+    const root = asRecord(payload.session) ?? payload;
+    const identity = asRecord(root.identity);
+    const data = asRecord(root.data);
+    const user = asRecord(data?.user);
+    const roleEntries = Array.isArray(user?.roles)
+      ? user.roles
+          .map((entry) => coerceText(entry) ?? coerceId(entry))
+          .filter((entry): entry is string => Boolean(entry))
+      : [];
+    const singleRole = coerceText(user?.role);
+    const roles =
+      roleEntries.length > 0 ? roleEntries : singleRole ? [singleRole] : undefined;
+    const resolved: CredentialIdentity = {
+      source: 'iapub/sessions',
+      userId: coerceId(identity?.user) ?? coerceId(user?.id),
+      fullName:
+        coerceText(user?.fullName) ?? coerceText(user?.name) ?? coerceText(user?.username),
+      teamId: coerceId(identity?.team),
+      teamName: coerceText(user?.teamName),
+      teamDomain: coerceText(identity?.domain),
+      ...(roles ? { roles } : {}),
+      consumerType:
+        coerceText(root.consumerType) ??
+        coerceText(data?.consumerType) ??
+        coerceText(user?.consumerType)
+    };
+    memoizedSessionIdentity = resolved;
+    return resolved;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/lib/postman/credential-identity.ts
+++ b/src/lib/postman/credential-identity.ts
@@ -1,8 +1,9 @@
 // Session-identity subset copied from the shared credential-identity foundation
 // (postman-repo-sync-action/src/lib/postman/credential-identity.ts). This action
 // makes no Postman asset calls; it resolves the access-token -> iapub session
-// only so telemetry can emit `account_type` from the resolved `consumerType`
-// (D1: an optional postman-access-token input used for telemetry enrichment).
+// only so telemetry can emit `account_type` from the resolved `consumerType`.
+// Access tokens may be supplied directly or minted via AccessTokenProvider
+// (postman-api-key -> POST /service-account-tokens) in telemetry-credentials.ts.
 
 export interface CredentialIdentity {
   source: 'pmak/me' | 'iapub/sessions';

--- a/src/lib/postman/telemetry-credentials.ts
+++ b/src/lib/postman/telemetry-credentials.ts
@@ -1,0 +1,54 @@
+import { resolveTelemetryAccountType } from './credential-identity.js';
+import { AccessTokenProvider } from './token-provider.js';
+import { POSTMAN_ENDPOINT_PROFILES } from './base-urls.js';
+
+export interface PrepareTelemetryCredentialsOptions {
+  postmanApiKey?: string;
+  postmanAccessToken?: string;
+  apiBaseUrl?: string;
+  onToken?: (token: string) => void;
+  fetchImpl?: typeof fetch;
+}
+
+export interface PreparedTelemetryCredentials {
+  provider?: AccessTokenProvider;
+  accountType?: string;
+}
+
+/**
+ * Wire AccessTokenProvider for telemetry enrichment. When only a service-account
+ * PMAK is present, mint a fresh access token so iapub session identity (and thus
+ * telemetry account_type) can still resolve. Mint failures are best-effort: they
+ * must not block AWS spec discovery.
+ */
+export async function prepareTelemetryCredentials(
+  options: PrepareTelemetryCredentialsOptions
+): Promise<PreparedTelemetryCredentials> {
+  const apiKey = String(options.postmanApiKey || '').trim();
+  const accessToken = String(options.postmanAccessToken || '').trim();
+  if (!apiKey && !accessToken) {
+    return {};
+  }
+
+  const provider = new AccessTokenProvider({
+    accessToken,
+    apiKey,
+    apiBaseUrl: options.apiBaseUrl || POSTMAN_ENDPOINT_PROFILES.prod.apiBaseUrl,
+    onToken: options.onToken,
+    ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {})
+  });
+
+  if (!accessToken && apiKey && provider.canRefresh()) {
+    try {
+      await provider.refresh();
+    } catch {
+      // Telemetry-only path: discovery continues without account_type enrichment.
+    }
+  }
+
+  const accountType = await resolveTelemetryAccountType(provider.current(), options.fetchImpl);
+  return {
+    provider,
+    ...(accountType ? { accountType } : {})
+  };
+}

--- a/src/lib/postman/token-provider.ts
+++ b/src/lib/postman/token-provider.ts
@@ -1,0 +1,156 @@
+import { retry } from '../retry.js';
+import { POSTMAN_ENDPOINT_PROFILES } from './base-urls.js';
+
+export interface AccessTokenProviderOptions {
+  /** Current access token (from action input or a prior mint). May be empty. */
+  accessToken?: string;
+  /** Service-account PMAK used to re-mint the access token. Empty disables refresh. */
+  apiKey?: string;
+  /** Public API base (e.g. https://api.getpostman.com); mint target host. */
+  apiBaseUrl?: string;
+  fetchImpl?: typeof fetch;
+  /** Max mint attempts per refresh (default 2). */
+  maxAttempts?: number;
+  /**
+   * Called with each freshly minted token so the caller can register it with
+   * the Actions log scrubber (core.setSecret) and a mutable masker. Re-minted
+   * tokens are unmasked unless this records them.
+   */
+  onToken?: (token: string) => void;
+  sleep?: (delayMs: number) => Promise<void>;
+}
+
+class MintError extends Error {
+  readonly permanent: boolean;
+
+  constructor(message: string, permanent: boolean) {
+    super(message);
+    this.name = 'MintError';
+    this.permanent = permanent;
+  }
+}
+
+function extractAccessToken(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== 'object') return undefined;
+  const record = payload as Record<string, unknown>;
+  const direct = record.access_token;
+  if (typeof direct === 'string' && direct.trim()) return direct.trim();
+  const session = record.session;
+  if (session && typeof session === 'object') {
+    const token = (session as Record<string, unknown>).token;
+    if (typeof token === 'string' && token.trim()) return token.trim();
+  }
+  return undefined;
+}
+
+/**
+ * Holds the live access token and re-mints it on expiry.
+ *
+ * Clients must read the token through {@link current} on every request rather
+ * than capturing it, so a refreshed token propagates to all in-flight clients.
+ * {@link refresh} is single-flight: concurrent callers await one mint, mirroring
+ * the app-version memoization in internal-integration-adapter.ts. The mint wire
+ * shape mirrors postman-resolve-service-token-action (POST /service-account-tokens
+ * with x-api-key + { apiKey }); the service-account PMAK is the renewal credential.
+ */
+export class AccessTokenProvider {
+  private token: string;
+  private readonly apiKey: string;
+  private readonly apiBaseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly maxAttempts: number;
+  private readonly onToken?: (token: string) => void;
+  private readonly sleep?: (delayMs: number) => Promise<void>;
+  private inflight?: Promise<string>;
+
+  constructor(options: AccessTokenProviderOptions) {
+    this.token = String(options.accessToken || '').trim();
+    this.apiKey = String(options.apiKey || '').trim();
+    this.apiBaseUrl = String(
+      options.apiBaseUrl || POSTMAN_ENDPOINT_PROFILES.prod.apiBaseUrl
+    ).replace(/\/+$/, '');
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.maxAttempts = Math.max(1, options.maxAttempts ?? 2);
+    this.onToken = options.onToken;
+    this.sleep = options.sleep;
+  }
+
+  current(): string {
+    return this.token;
+  }
+
+  /** True when a PMAK is present, so an expired token can be re-minted. */
+  canRefresh(): boolean {
+    return Boolean(this.apiKey);
+  }
+
+  refresh(): Promise<string> {
+    this.inflight ??= this.mintWithRetry().finally(() => {
+      this.inflight = undefined;
+    });
+    return this.inflight;
+  }
+
+  private async mintWithRetry(): Promise<string> {
+    if (!this.apiKey) {
+      throw new Error(
+        'postman: the access token expired and cannot be refreshed because no postman-api-key is present. ' +
+          'Service-account access tokens expire after about 1 to 1.5 hours. ' +
+          'Re-mint a fresh token (postman-resolve-service-token-action) and re-run.'
+      );
+    }
+    const token = await retry(() => this.mintOnce(), {
+      maxAttempts: this.maxAttempts,
+      delayMs: 1000,
+      backoffMultiplier: 2,
+      ...(this.sleep ? { sleep: this.sleep } : {}),
+      shouldRetry: (error) => !(error instanceof MintError && error.permanent)
+    });
+    this.token = token;
+    this.onToken?.(token);
+    return token;
+  }
+
+  private async mintOnce(): Promise<string> {
+    const response = await this.fetchImpl(`${this.apiBaseUrl}/service-account-tokens`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': this.apiKey
+      },
+      body: JSON.stringify({ apiKey: this.apiKey })
+    });
+
+    const body = await response.text().catch(() => '');
+    if (!response.ok) {
+      const status = response.status;
+      if (status === 401 || status === 403) {
+        throw new MintError(
+          `postman: re-mint failed because the postman-api-key was rejected (PMAK rejected, HTTP ${status}); ` +
+            'confirm it is a valid, enabled service-account PMAK for the intended team.',
+          true
+        );
+      }
+      if (status === 400 && body.toLowerCase().includes('service accounts not enabled')) {
+        throw new MintError(
+          'postman: re-mint failed because service accounts are not enabled for this team; ' +
+            'enable them in Team Settings or use a team where they are.',
+          true
+        );
+      }
+      throw new MintError(`postman: re-mint failed (service-account-tokens HTTP ${status}).`, false);
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(body);
+    } catch {
+      parsed = undefined;
+    }
+    const token = extractAccessToken(parsed);
+    if (!token) {
+      throw new MintError('postman: re-mint succeeded but no access token was returned.', false);
+    }
+    return token;
+  }
+}

--- a/src/lib/retry.ts
+++ b/src/lib/retry.ts
@@ -1,0 +1,79 @@
+export interface RetryDecisionContext {
+  attempt: number;
+  maxAttempts: number;
+}
+
+export interface RetryContext extends RetryDecisionContext {
+  delayMs: number;
+  error: unknown;
+}
+
+export interface RetryOptions {
+  maxAttempts?: number;
+  delayMs?: number;
+  backoffMultiplier?: number;
+  maxDelayMs?: number;
+  onRetry?: (context: RetryContext) => void | Promise<void>;
+  shouldRetry?: (error: unknown, context: RetryDecisionContext) => boolean;
+  sleep?: (delayMs: number) => Promise<void>;
+}
+
+export function sleep(delayMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
+function normalizeRetryOptions(options: RetryOptions): Required<RetryOptions> {
+  return {
+    maxAttempts: Math.max(1, options.maxAttempts ?? 3),
+    delayMs: Math.max(0, options.delayMs ?? 2000),
+    backoffMultiplier: Math.max(1, options.backoffMultiplier ?? 1),
+    maxDelayMs:
+      options.maxDelayMs === undefined
+        ? Number.POSITIVE_INFINITY
+        : Math.max(0, options.maxDelayMs),
+    onRetry: options.onRetry ?? (async () => undefined),
+    shouldRetry: options.shouldRetry ?? (() => true),
+    sleep: options.sleep ?? sleep
+  };
+}
+
+export async function retry<T>(
+  operation: () => Promise<T>,
+  options: RetryOptions = {}
+): Promise<T> {
+  const normalized = normalizeRetryOptions(options);
+  let nextDelayMs = normalized.delayMs;
+
+  for (let attempt = 1; attempt <= normalized.maxAttempts; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      const shouldRetry =
+        attempt < normalized.maxAttempts &&
+        normalized.shouldRetry(error, {
+          attempt,
+          maxAttempts: normalized.maxAttempts
+        });
+
+      if (!shouldRetry) {
+        throw error;
+      }
+
+      await normalized.onRetry({
+        attempt,
+        maxAttempts: normalized.maxAttempts,
+        delayMs: nextDelayMs,
+        error
+      });
+      await normalized.sleep(nextDelayMs);
+      nextDelayMs = Math.min(
+        normalized.maxDelayMs,
+        Math.round(nextDelayMs * normalized.backoffMultiplier)
+      );
+    }
+  }
+
+  throw new Error('Retry exhausted without returning or throwing');
+}

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -42,6 +42,7 @@ describe('action contract', () => {
     'gateway-id': false,
     stage: false,
     'output-dir': false,
+    'postman-api-key': false,
     'postman-access-token': false
   } as const;
   const expectedExistingOutputDescriptions = {

--- a/tests/contract.test.ts
+++ b/tests/contract.test.ts
@@ -41,7 +41,8 @@ describe('action contract', () => {
     'aws-region': true,
     'gateway-id': false,
     stage: false,
-    'output-dir': false
+    'output-dir': false,
+    'postman-access-token': false
   } as const;
   const expectedExistingOutputDescriptions = {
     'resolution-json': 'JSON resolution result describing status, source type, confidence, and evidence.',

--- a/tests/no-collection-v2.test.ts
+++ b/tests/no-collection-v2.test.ts
@@ -1,0 +1,159 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const ACTION_ROOT = resolve(import.meta.dirname, '..');
+const SRC_ROOT = join(ACTION_ROOT, 'src');
+
+type Violation = {
+  file: string;
+  line: number;
+  pattern: string;
+  text: string;
+};
+
+function walkTypeScriptFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const abs = join(dir, entry);
+    if (statSync(abs).isDirectory()) {
+      return walkTypeScriptFiles(abs);
+    }
+    return abs.endsWith('.ts') ? [abs] : [];
+  });
+}
+
+/** Remove // and block comments without touching string/template contents. */
+function stripComments(source: string): string {
+  let result = '';
+  let i = 0;
+
+  while (i < source.length) {
+    const ch = source[i];
+    const next = source[i + 1];
+
+    if (ch === '/' && next === '/') {
+      i += 2;
+      while (i < source.length && source[i] !== '\n') {
+        i += 1;
+      }
+      result += '\n';
+      continue;
+    }
+
+    if (ch === '/' && next === '*') {
+      i += 2;
+      while (i < source.length && !(source[i] === '*' && source[i + 1] === '/')) {
+        i += 1;
+      }
+      i += 2;
+      result += '\n';
+      continue;
+    }
+
+    if (ch === '"' || ch === "'" || ch === '`') {
+      result += ch;
+      i += 1;
+      while (i < source.length) {
+        if (source[i] === '\\') {
+          result += source[i] + source[i + 1];
+          i += 2;
+          continue;
+        }
+        if (source[i] === ch) {
+          result += source[i];
+          i += 1;
+          break;
+        }
+        result += source[i];
+        i += 1;
+      }
+      continue;
+    }
+
+    result += ch;
+    i += 1;
+  }
+
+  return result;
+}
+
+function isPmakAssetClient(relPath: string): boolean {
+  const base = relPath.split('/').pop() ?? '';
+  return base === 'postman-assets-client.ts' || base === 'postman-smoke-client.ts';
+}
+
+/** PMAK public-REST collection CRUD — never allowlisted. Scoped to PMAK asset clients only. */
+function hasPmakCollectionCrud(relPath: string, line: string): boolean {
+  if (!isPmakAssetClient(relPath)) {
+    return false;
+  }
+  if (/\/collections\?/.test(line)) {
+    return true;
+  }
+  if (/['"`]\/collections\/['"`]/.test(line)) {
+    return true;
+  }
+  return line.includes('/collections/${');
+}
+
+function matchPatterns(relPath: string, line: string): string[] {
+  const hits: string[] = [];
+
+  if (/collection\/v2\.(?:0|1)\.0/.test(line)) {
+    hits.push('v2-schema-url');
+  }
+  if (hasPmakCollectionCrud(relPath, line)) {
+    hits.push('pmak-collection-crud');
+  }
+  if (/format\s*:\s*['"]v2\.1\.0['"]/.test(line)) {
+    hits.push('format-v2-literal');
+  }
+  if (
+    /\bfrom\s+['"]postman-collection['"]/.test(line) ||
+    /\bimport\s+['"]postman-collection['"]/.test(line)
+  ) {
+    hits.push('postman-collection-import');
+  }
+  if (/\bimport\b/.test(line) && /@postman\/runtime\.models\/v2/.test(line)) {
+    hits.push('runtime-models-v2-import');
+  }
+
+  return hits;
+}
+
+function scanSourceFile(absPath: string): Violation[] {
+  const relPath = relative(ACTION_ROOT, absPath).replace(/\\/g, '/');
+  const stripped = stripComments(readFileSync(absPath, 'utf8'));
+  const violations: Violation[] = [];
+
+  stripped.split('\n').forEach((line, index) => {
+    for (const pattern of matchPatterns(relPath, line)) {
+      violations.push({
+        file: relPath,
+        line: index + 1,
+        pattern,
+        text: line.trim()
+      });
+    }
+  });
+
+  return violations;
+}
+
+function formatViolations(violations: Violation[]): string {
+  return violations
+    .map((v) => `${v.file}:${v.line}: ${v.pattern} — ${v.text}`)
+    .join('\n');
+}
+
+describe('no collection v2.x in production src/', () => {
+  it('has no forbidden collection v2.x patterns', () => {
+    const files = walkTypeScriptFiles(SRC_ROOT);
+    expect(files.length).toBeGreaterThan(0);
+
+    const violations = files.flatMap(scanSourceFile);
+
+    expect(violations, formatViolations(violations)).toEqual([]);
+  });
+});

--- a/tests/no-pmak-asset-or-newman.test.ts
+++ b/tests/no-pmak-asset-or-newman.test.ts
@@ -1,0 +1,159 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const ACTION_ROOT = resolve(import.meta.dirname, '..');
+const SRC_ROOT = join(ACTION_ROOT, 'src');
+
+type PatternId = 'newman' | 'pmak-header' | 'pmak-cli-login';
+
+/**
+ * Sanctioned PMAK / Postman-CLI sites. PMAK survives ONLY for:
+ *   1. minting/re-minting the service-account access token (token-provider mint POST),
+ *   2. Insights linking (akita rejects service accounts — insights action only),
+ *   3. `postman login --with-api-key` (the Postman CLI has no access-token login),
+ * plus the user-approved read-only `GET /me` identity preflight (credential-identity)
+ * and repo-sync's CI-key reuse-vs-mint /me check. Every Postman ASSET op runs on the
+ * access-token gateway; a new `x-api-key:` header or `--with-api-key` outside this list
+ * is a forbidden PMAK asset op. Newman is banned everywhere (never allowlisted): it
+ * cannot run Collection v3, so only the Postman CLI (`postman collection run`) is allowed.
+ */
+const ALLOWLIST: Record<string, PatternId[]> = {
+  'src/lib/postman/token-provider.ts': ['pmak-header']
+};
+
+type Violation = { file: string; line: number; pattern: PatternId; text: string };
+
+function walkTypeScriptFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const abs = join(dir, entry);
+    if (statSync(abs).isDirectory()) {
+      return walkTypeScriptFiles(abs);
+    }
+    return abs.endsWith('.ts') ? [abs] : [];
+  });
+}
+
+/** Remove // and block comments without touching string/template contents. */
+function stripComments(source: string): string {
+  let result = '';
+  let i = 0;
+
+  while (i < source.length) {
+    const ch = source[i];
+    const next = source[i + 1];
+
+    if (ch === '/' && next === '/') {
+      i += 2;
+      while (i < source.length && source[i] !== '\n') {
+        i += 1;
+      }
+      result += '\n';
+      continue;
+    }
+
+    if (ch === '/' && next === '*') {
+      i += 2;
+      while (i < source.length && !(source[i] === '*' && source[i + 1] === '/')) {
+        i += 1;
+      }
+      i += 2;
+      result += '\n';
+      continue;
+    }
+
+    if (ch === '"' || ch === "'" || ch === '`') {
+      result += ch;
+      i += 1;
+      while (i < source.length) {
+        if (source[i] === '\\') {
+          result += source[i] + source[i + 1];
+          i += 2;
+          continue;
+        }
+        if (source[i] === ch) {
+          result += source[i];
+          i += 1;
+          break;
+        }
+        result += source[i];
+        i += 1;
+      }
+      continue;
+    }
+
+    result += ch;
+    i += 1;
+  }
+
+  return result;
+}
+
+function matchPatterns(line: string): PatternId[] {
+  const hits: PatternId[] = [];
+  if (/['"]newman['"]|\bnewman\s+run\b|\bnewman\s*\.\s*run\b/i.test(line)) {
+    hits.push('newman');
+  }
+  if (/['"]x-api-key['"]\s*:/i.test(line)) {
+    hits.push('pmak-header');
+  }
+  if (/--with-api-key/.test(line)) {
+    hits.push('pmak-cli-login');
+  }
+  return hits;
+}
+
+function scanSourceFile(absPath: string): Violation[] {
+  const relPath = relative(ACTION_ROOT, absPath).replace(/\\/g, '/');
+  const stripped = stripComments(readFileSync(absPath, 'utf8'));
+  const hits: Violation[] = [];
+  stripped.split('\n').forEach((line, index) => {
+    for (const pattern of matchPatterns(line)) {
+      hits.push({ file: relPath, line: index + 1, pattern, text: line.trim() });
+    }
+  });
+  return hits;
+}
+
+function isSanctioned(v: Violation): boolean {
+  // Newman is never allowlisted; x-api-key / --with-api-key only in the sanctioned files.
+  return v.pattern !== 'newman' && (ALLOWLIST[v.file]?.includes(v.pattern) ?? false);
+}
+
+function format(vs: Violation[]): string {
+  return vs.map((v) => `${v.file}:${v.line}: ${v.pattern} — ${v.text}`).join('\n');
+}
+
+describe('no PMAK asset op or Newman in production src/', () => {
+  const allHits = walkTypeScriptFiles(SRC_ROOT).flatMap(scanSourceFile);
+
+  it('has no un-sanctioned x-api-key / --with-api-key, and no Newman anywhere', () => {
+    const violations = allHits.filter((v) => !isSanctioned(v));
+    expect(violations, format(violations)).toEqual([]);
+  });
+
+  it('has no stale allowlist entries (every sanctioned site still exists)', () => {
+    const stale: string[] = [];
+    for (const [file, patterns] of Object.entries(ALLOWLIST)) {
+      for (const pattern of patterns) {
+        if (!allHits.some((v) => v.file === file && v.pattern === pattern)) {
+          stale.push(`${file}: ${pattern}`);
+        }
+      }
+    }
+    expect(stale, `stale allowlist entries:\n${stale.join('\n')}`).toEqual([]);
+  });
+
+  it('declares no Newman dependency in package.json', () => {
+    const pkg = JSON.parse(readFileSync(join(ACTION_ROOT, 'package.json'), 'utf8')) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    const newmanDeps = [
+      ...Object.keys(pkg.dependencies ?? {}),
+      ...Object.keys(pkg.devDependencies ?? {})
+    ].filter((name) => /(^|[/@-])newman([/-]|$)/i.test(name));
+    expect(newmanDeps, `Newman dependencies: ${newmanDeps.join(', ')}`).toEqual([]);
+  });
+});

--- a/tests/telemetry-account-type.test.ts
+++ b/tests/telemetry-account-type.test.ts
@@ -4,6 +4,7 @@ import {
   __resetIdentityMemo,
   resolveTelemetryAccountType
 } from '../src/lib/postman/credential-identity.js';
+import { prepareTelemetryCredentials } from '../src/lib/postman/telemetry-credentials.js';
 
 beforeEach(() => __resetIdentityMemo());
 afterEach(() => vi.restoreAllMocks());
@@ -30,5 +31,55 @@ describe('resolveTelemetryAccountType (aws-spec-discovery telemetry enrichment)'
   it('returns undefined on a probe failure rather than throwing', async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(new Response('nope', { status: 401 }));
     await expect(resolveTelemetryAccountType('pma_at_service', fetchImpl)).resolves.toBeUndefined();
+  });
+});
+
+describe('prepareTelemetryCredentials', () => {
+  it('mints an access token from postman-api-key when no access token is supplied', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (url) => {
+      if (String(url).includes('/service-account-tokens')) {
+        return new Response(JSON.stringify({ access_token: 'pma_at_minted' }), {
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+      if (String(url).includes('/api/sessions/current')) {
+        return new Response(
+          JSON.stringify({ session: { identity: { team: '10490519' }, consumerType: 'service' } }),
+          { headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      throw new Error(`unexpected fetch: ${String(url)}`);
+    });
+
+    const onToken = vi.fn();
+    const result = await prepareTelemetryCredentials({
+      postmanApiKey: 'PMAK-test',
+      fetchImpl,
+      onToken
+    });
+
+    expect(result.provider?.current()).toBe('pma_at_minted');
+    expect(result.accountType).toBe('service');
+    expect(onToken).toHaveBeenCalledWith('pma_at_minted');
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.getpostman.com/service-account-tokens',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('returns empty when neither PMAK nor access token is present', async () => {
+    await expect(prepareTelemetryCredentials({})).resolves.toEqual({});
+  });
+
+  it('does not throw when mint fails (best-effort telemetry)', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(new Response('nope', { status: 403 }));
+    await expect(
+      prepareTelemetryCredentials({
+        postmanApiKey: 'PMAK-bad',
+        fetchImpl
+      })
+    ).resolves.toEqual({
+      provider: expect.objectContaining({ current: expect.any(Function) })
+    });
   });
 });

--- a/tests/telemetry-account-type.test.ts
+++ b/tests/telemetry-account-type.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  __resetIdentityMemo,
+  resolveTelemetryAccountType
+} from '../src/lib/postman/credential-identity.js';
+
+beforeEach(() => __resetIdentityMemo());
+afterEach(() => vi.restoreAllMocks());
+
+describe('resolveTelemetryAccountType (aws-spec-discovery telemetry enrichment)', () => {
+  it('returns the session consumerType when an access token resolves an iapub session', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (url, init) => {
+      expect(String(url)).toBe('https://iapub.postman.co/api/sessions/current');
+      expect((init?.headers as Record<string, string>)['x-access-token']).toBe('pma_at_service');
+      return new Response(
+        JSON.stringify({ session: { identity: { team: '10490519' }, consumerType: 'service_account' } }),
+        { headers: { 'Content-Type': 'application/json' } }
+      );
+    });
+    await expect(resolveTelemetryAccountType('pma_at_service', fetchImpl)).resolves.toBe('service_account');
+  });
+
+  it('returns undefined when no access token is present (account_type stays unknown)', async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    await expect(resolveTelemetryAccountType('', fetchImpl)).resolves.toBeUndefined();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined on a probe failure rather than throwing', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(new Response('nope', { status: 401 }));
+    await expect(resolveTelemetryAccountType('pma_at_service', fetchImpl)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
Adds an optional `postman-access-token` (and a PMAK-to-token mint) used only to resolve the telemetry `account_type` (the session `consumerType`). This action makes no Postman asset call; its only Postman touch is anonymous telemetry.

- Docs now make clear that the Postman creds are telemetry-only here, since AWS credentials drive discovery.

## Versioning
An additive, optional input. Targeted at v1.1.0 (minor).

## Validation
Unit, typecheck, lint, build, and check:dist are green.

_Holding off on the merge for now; this is a coordinated suite rollout._
