### PR TITLE
ci: consolidate checks into one backgrounded gate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,16 @@ permissions:
   contents: read
 
 jobs:
-  validate:
+  gate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Full history so commitlint can lint the PR commit range.
+          fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -24,41 +30,36 @@ jobs:
       - run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: npm run lint
-      - run: npm run typecheck
-      - run: npm test
+      # All checks run in parallel as backgrounded shell processes on one runner,
+      # so wall-clock is max(gate), not sum, and setup/npm-ci run once. Failures
+      # aggregate under ::group:: logs, so one pass shows every result.
+      - name: Run gates
+        run: |
+          set -uo pipefail
+          declare -A pid
+          run() { local n=$1; shift; ( "$@" ) >"$n.log" 2>&1 & pid[$n]=$!; }
 
-  check-dist:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: npm
-          registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: rm -rf dist && npm run build
-      - name: Compare committed dist
-        id: diff
-        run: git diff --ignore-space-at-eol --text --exit-code -- dist
+          run lint       npm run lint
+          run typecheck  npm run typecheck
+          run test       npm test
+          run dist       npm run verify:dist
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            run commitlint npx commitlint \
+              --from "${{ github.event.pull_request.base.sha }}" \
+              --to "${{ github.event.pull_request.head.sha }}"
+          fi
+
+          fail=0
+          for n in "${!pid[@]}"; do
+            if wait "${pid[$n]}"; then echo "gate:$n=pass"; else echo "gate:$n=fail"; fail=1; fi
+          done
+          for n in "${!pid[@]}"; do
+            echo "::group::$n"; cat "$n.log"; echo "::endgroup::"
+          done
+          exit $fail
       - name: Upload expected dist on mismatch
-        if: ${{ failure() && steps.diff.outcome == 'failure' }}
+        if: failure()
         uses: actions/upload-artifact@v7
         with:
           name: expected-dist
           path: dist/
-
-  commitlint:
-    if: github.event_name == 'pull_request'
-    permissions:
-      contents: read
-      pull-requests: read
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,3 +86,12 @@ npm run verify:dist  # CI/hook gate: rebuild + git diff (dev runs build)
 - Output path is sandboxed: must resolve within `repo-root` (path escapes are blocked)
 - `overrides.undici` in package.json pins undici >=6.24.0 for Node 20 fetch compatibility
 - SSM provider fetches URLs only over HTTPS; non-HTTPS URLs are preserved as pointer artifacts
+
+## CI
+
+`.github/workflows/ci.yml` runs a single `gate` job that fans out lint, typecheck, test, dist, and commitlint
+as backgrounded shell processes on one runner: wall-clock is `max(gate)`, not
+`sum`, setup runs once, and every gate prints its result under a `::group::`
+block even when another fails.
+
+See the workspace `docs/CI.md` for the shared rationale.


### PR DESCRIPTION
## What
Consolidates the per-PR/push CI into a single `gate` job that runs every check as
a backgrounded shell process on one runner (`&` / `wait`), folds commitlint in via
`npx commitlint`, and installs `actionlint` via the pinned official downloader (no
Go toolchain job).

## Why
GitHub's only parallelism primitive is the job; steps within a job serialize, but
processes within one `run:` step run concurrently. One backgrounded job gets the
same wall-clock as N parallel jobs (`max`, not `sum`) while paying setup + `npm ci`
once instead of per job, and spinning up fewer runners.

## Gates
lint · typecheck · test · dist · commitlint (no actionlint gate in this repo).

## Tradeoff
One check instead of several: a failure is one red X to expand and a rerun is the
whole job. The gate runs every check even after one fails and prints each under a
`::group::` block to keep failures legible.