### PR TITLE
fix(cli): harden Wave 1 entrypoint and input safety

### DIFF
--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -168462,9 +168462,6 @@ function printVersion(writeStdout) {
 `);
 }
 function parseCliArgs(argv, env2 = process.env) {
-  const knownInputEnvNames = new Set(CLI_INPUT_NAMES.map((name) => normalizeCliFlag(name)));
-  const knownMetaEnvNames = /* @__PURE__ */ new Set(["INPUT_RESULT_JSON", "INPUT_DOTENV_PATH"]);
-  const knownEnvNames = /* @__PURE__ */ new Set([...knownInputEnvNames, ...knownMetaEnvNames]);
   const inputEnv = { ...env2 };
   const seen = /* @__PURE__ */ new Set();
   let command5 = "run";
@@ -168511,22 +168508,18 @@ function parseCliArgs(argv, env2 = process.env) {
       throw new Error(`Missing value for --${optionName}`);
     }
     if (optionName === "result-json") {
-      const envValue = normalizeInputish(env2.INPUT_RESULT_JSON);
-      if (envValue !== void 0 && envValue !== rawValue) {
-        throw new Error("Conflicting values for --result-json and INPUT_RESULT_JSON");
-      }
       resultJsonPath = rawValue;
       continue;
     }
     if (optionName === "dotenv-path") {
-      const envValue = normalizeInputish(env2.INPUT_DOTENV_PATH);
-      if (envValue !== void 0 && envValue !== rawValue) {
-        throw new Error("Conflicting values for --dotenv-path and INPUT_DOTENV_PATH");
-      }
       dotenvPath = rawValue;
       continue;
     }
     const envName = normalizeCliFlag(optionName);
+    const runnerEnvName = `INPUT_${optionName.toUpperCase()}`;
+    if (runnerEnvName !== envName) {
+      delete inputEnv[runnerEnvName];
+    }
     inputEnv[envName] = rawValue;
   }
   if (command5 !== "run") {
@@ -168534,16 +168527,6 @@ function parseCliArgs(argv, env2 = process.env) {
       throw new Error(`Option --${command5} cannot be combined with other options`);
     }
     return { kind: command5 };
-  }
-  for (const key of Object.keys(env2)) {
-    if (!key.startsWith("INPUT_")) {
-      continue;
-    }
-    const runnerNormalized = `INPUT_${key.slice("INPUT_".length).replace(/-/g, "_")}`;
-    if (knownEnvNames.has(key) || knownEnvNames.has(runnerNormalized)) {
-      continue;
-    }
-    throw new Error(`Unknown INPUT alias: ${key}`);
   }
   return {
     kind: "run",

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -158475,6 +158475,7 @@ __export(cli_exports, {
   toDotenv: () => toDotenv
 });
 module.exports = __toCommonJS(cli_exports);
+var import_node_fs4 = require("node:fs");
 var import_promises11 = require("node:fs/promises");
 var import_node_path16 = __toESM(require("node:path"), 1);
 
@@ -166203,8 +166204,22 @@ function normalizeInputValue(value) {
   return trimmed ? trimmed : void 0;
 }
 function getInput(name, env2 = process.env) {
-  const envName = `INPUT_${name.replace(/-/g, "_").toUpperCase()}`;
-  return normalizeInputValue(env2[envName]);
+  const normalizedName = `INPUT_${name.replace(/-/g, "_").toUpperCase()}`;
+  const runnerName = `INPUT_${name.replace(/ /g, "_").toUpperCase()}`;
+  const normalizedRaw = env2[normalizedName];
+  const runnerRaw = runnerName === normalizedName ? void 0 : env2[runnerName];
+  const hasNormalized = normalizedRaw !== void 0;
+  const hasRunner = runnerRaw !== void 0;
+  if (hasNormalized && hasRunner) {
+    const normalizedValue = normalizeInputValue(normalizedRaw);
+    const runnerValue = normalizeInputValue(runnerRaw);
+    if (normalizedValue !== runnerValue) {
+      throw new Error(
+        `Conflicting values for ${name}: ${normalizedName}=${JSON.stringify(normalizedValue)} vs ${runnerName}=${JSON.stringify(runnerValue)}`
+      );
+    }
+  }
+  return normalizeInputValue(hasNormalized ? normalizedRaw : runnerRaw);
 }
 function parseBoolean2(input, inputName, fallback2 = true) {
   if (!input) {
@@ -166219,13 +166234,16 @@ function parseBoolean2(input, inputName, fallback2 = true) {
   }
   throw new Error(`${inputName} must be a boolean-like value, got: ${input}`);
 }
-function parsePositiveInteger(input, inputName, fallback2) {
+function parseBoundedInteger(input, inputName, fallback2, min, max) {
   if (!input) {
     return fallback2;
   }
-  const value = Number.parseInt(input, 10);
-  if (!Number.isFinite(value) || value < 0) {
-    throw new Error(`${inputName} must be a non-negative integer, got: ${input}`);
+  if (!/^\d+$/.test(input)) {
+    throw new Error(`${inputName} must be a non-negative integer between ${min} and ${max}, got: ${input}`);
+  }
+  const value = Number(input);
+  if (!Number.isSafeInteger(value) || value < min || value > max) {
+    throw new Error(`${inputName} must be a non-negative integer between ${min} and ${max}, got: ${input}`);
   }
   return value;
 }
@@ -166271,9 +166289,9 @@ function parseStringArrayJson(raw, inputName) {
 }
 function resolveInputs(env2 = process.env) {
   const mode = parseMode(getInput("mode", env2) ?? DEFAULT_MODE);
-  const awsRegion = getInput("aws-region", env2) ?? "";
+  const awsRegion = getInput("aws-region", env2) ?? normalizeInputValue(env2.AWS_REGION) ?? normalizeInputValue(env2.AWS_DEFAULT_REGION) ?? "";
   if (!awsRegion) {
-    throw new Error("aws-region is required");
+    throw new Error("aws-region is required (set --aws-region / INPUT_AWS_REGION, or AWS_REGION / AWS_DEFAULT_REGION)");
   }
   const repoRoot = getInput("repo-root", env2) ?? normalizeInputValue(env2.GITHUB_WORKSPACE) ?? normalizeInputValue(env2.CI_PROJECT_DIR) ?? normalizeInputValue(env2.BITBUCKET_CLONE_DIR) ?? normalizeInputValue(env2.BUILD_SOURCESDIRECTORY) ?? DEFAULT_REPO_ROOT;
   const gatewayId = getInput("gateway-id", env2);
@@ -166325,12 +166343,12 @@ function resolveInputs(env2 = process.env) {
     apiFilter,
     serviceMapping: parseServiceMapping(serviceMappingRaw),
     outputDir,
-    maxCandidates: parsePositiveInteger(maxCandidatesRaw, "max-candidates", 50),
+    maxCandidates: parseBoundedInteger(maxCandidatesRaw, "max-candidates", 50, 1, 1e4),
     dryRun: parseBoolean2(dryRunRaw, "dry-run", false),
     preflightChecks: parseBoolean2(preflightChecksRaw, "preflight-checks", true),
     preflightPermissionProbe: parseBoolean2(preflightPermissionProbeRaw, "preflight-permission-probe", true),
-    requestTimeoutMs: parsePositiveInteger(requestTimeoutMsRaw, "request-timeout-ms", 3e4),
-    maxAttempts: parsePositiveInteger(maxAttemptsRaw, "max-attempts", 3),
+    requestTimeoutMs: parseBoundedInteger(requestTimeoutMsRaw, "request-timeout-ms", 3e4, 1, 3e5),
+    maxAttempts: parseBoundedInteger(maxAttemptsRaw, "max-attempts", 3, 1, 100),
     includeV2: parseBoolean2(includeV2Raw, "include-v2", true)
   };
 }
@@ -168393,61 +168411,153 @@ var ConsoleReporter = class {
     console.error(`warning: ${sanitizeLogMessage(message)}`);
   }
 };
-function readFlag(argv, name) {
-  const prefix = `--${name}=`;
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (arg === `--${name}`) {
-      return argv[index + 1];
-    }
-    if (arg?.startsWith(prefix)) {
-      return arg.slice(prefix.length);
-    }
-  }
-  return void 0;
-}
+var CLI_INPUT_NAMES = [
+  "mode",
+  "aws-region",
+  "gateway-id",
+  "repo-url",
+  "repo-slug",
+  "git-provider",
+  "ref",
+  "sha",
+  "repo-root",
+  "expected-service-name",
+  "expected-gateway-ids-json",
+  "stage",
+  "api-filter",
+  "service-mapping-json",
+  "output-dir",
+  "max-candidates",
+  "dry-run",
+  "preflight-checks",
+  "preflight-permission-probe",
+  "request-timeout-ms",
+  "max-attempts",
+  "include-v2",
+  "postman-api-key",
+  "postman-access-token"
+];
+var META_OPTIONS = /* @__PURE__ */ new Set(["result-json", "dotenv-path", "help", "version"]);
+var KNOWN_OPTIONS = /* @__PURE__ */ new Set([...CLI_INPUT_NAMES, ...META_OPTIONS]);
 function normalizeCliFlag(name) {
   return `INPUT_${name.replace(/-/g, "_").toUpperCase()}`;
 }
+function printHelp(writeStdout) {
+  writeStdout(`Usage: postman-aws-spec-discovery [options]
+
+Discover AWS-hosted API specs and emit JSON / dotenv artifacts for downstream
+Postman onboarding steps.
+
+Options mirror action inputs as --kebab-case flags (for example --aws-region,
+--dry-run, --output-dir). Additional CLI-only options:
+
+  --result-json <path>   Write the full result JSON (default: postman-aws-spec-discovery-result.json)
+  --dotenv-path <path>   Optional dotenv export for downstream jobs
+  --help                 Show this help text and exit
+  --version              Print the package version and exit
+`);
+}
+function printVersion(writeStdout) {
+  writeStdout(`${resolveActionVersion2()}
+`);
+}
 function parseCliArgs(argv, env2 = process.env) {
-  const inputNames = [
-    "mode",
-    "aws-region",
-    "gateway-id",
-    "repo-url",
-    "repo-slug",
-    "git-provider",
-    "ref",
-    "sha",
-    "repo-root",
-    "expected-service-name",
-    "expected-gateway-ids-json",
-    "stage",
-    "api-filter",
-    "service-mapping-json",
-    "output-dir",
-    "max-candidates",
-    "dry-run",
-    "preflight-checks",
-    "preflight-permission-probe",
-    "request-timeout-ms",
-    "max-attempts",
-    "include-v2",
-    "postman-api-key",
-    "postman-access-token"
-  ];
+  const knownInputEnvNames = new Set(CLI_INPUT_NAMES.map((name) => normalizeCliFlag(name)));
+  const knownMetaEnvNames = /* @__PURE__ */ new Set(["INPUT_RESULT_JSON", "INPUT_DOTENV_PATH"]);
+  const knownEnvNames = /* @__PURE__ */ new Set([...knownInputEnvNames, ...knownMetaEnvNames]);
   const inputEnv = { ...env2 };
-  for (const name of inputNames) {
-    const value = readFlag(argv, name);
-    if (value !== void 0) {
-      inputEnv[normalizeCliFlag(name)] = value;
+  const seen = /* @__PURE__ */ new Set();
+  let command5 = "run";
+  let resultJsonPath = normalizeInputish(env2.INPUT_RESULT_JSON) ?? "postman-aws-spec-discovery-result.json";
+  let dotenvPath = normalizeInputish(env2.INPUT_DOTENV_PATH);
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token) {
+      continue;
     }
+    if (!token.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${token}`);
+    }
+    const raw = token.slice(2);
+    const equalsIndex = raw.indexOf("=");
+    const optionName = equalsIndex >= 0 ? raw.slice(0, equalsIndex) : raw;
+    if (!optionName || !KNOWN_OPTIONS.has(optionName)) {
+      throw new Error(`Unknown option: --${optionName || raw}`);
+    }
+    if (seen.has(optionName)) {
+      throw new Error(`Duplicate option: --${optionName}`);
+    }
+    seen.add(optionName);
+    if (optionName === "help" || optionName === "version") {
+      if (equalsIndex >= 0) {
+        throw new Error(`Option --${optionName} does not accept a value`);
+      }
+      command5 = optionName;
+      continue;
+    }
+    let rawValue;
+    if (equalsIndex >= 0) {
+      rawValue = raw.slice(equalsIndex + 1);
+    } else {
+      const next = argv[index + 1];
+      if (next !== void 0 && !next.startsWith("--")) {
+        rawValue = next;
+        index += 1;
+      } else {
+        throw new Error(`Missing value for --${optionName}`);
+      }
+    }
+    if (rawValue === "") {
+      throw new Error(`Missing value for --${optionName}`);
+    }
+    if (optionName === "result-json") {
+      const envValue = normalizeInputish(env2.INPUT_RESULT_JSON);
+      if (envValue !== void 0 && envValue !== rawValue) {
+        throw new Error("Conflicting values for --result-json and INPUT_RESULT_JSON");
+      }
+      resultJsonPath = rawValue;
+      continue;
+    }
+    if (optionName === "dotenv-path") {
+      const envValue = normalizeInputish(env2.INPUT_DOTENV_PATH);
+      if (envValue !== void 0 && envValue !== rawValue) {
+        throw new Error("Conflicting values for --dotenv-path and INPUT_DOTENV_PATH");
+      }
+      dotenvPath = rawValue;
+      continue;
+    }
+    const envName = normalizeCliFlag(optionName);
+    inputEnv[envName] = rawValue;
+  }
+  if (command5 !== "run") {
+    if (seen.size !== 1) {
+      throw new Error(`Option --${command5} cannot be combined with other options`);
+    }
+    return { kind: command5 };
+  }
+  for (const key of Object.keys(env2)) {
+    if (!key.startsWith("INPUT_")) {
+      continue;
+    }
+    const runnerNormalized = `INPUT_${key.slice("INPUT_".length).replace(/-/g, "_")}`;
+    if (knownEnvNames.has(key) || knownEnvNames.has(runnerNormalized)) {
+      continue;
+    }
+    throw new Error(`Unknown INPUT alias: ${key}`);
   }
   return {
+    kind: "run",
     inputEnv,
-    resultJsonPath: readFlag(argv, "result-json") ?? "postman-aws-spec-discovery-result.json",
-    dotenvPath: readFlag(argv, "dotenv-path")
+    resultJsonPath,
+    dotenvPath
   };
+}
+function normalizeInputish(value) {
+  if (value === void 0) {
+    return void 0;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : void 0;
 }
 function toDotenv(outputs) {
   const envPairs = {
@@ -168488,15 +168598,32 @@ async function writeOptionalFile(filePath, content) {
   await (0, import_promises11.mkdir)(import_node_path16.default.dirname(resolved), { recursive: true });
   await (0, import_promises11.writeFile)(resolved, content, "utf8");
 }
-async function runCli(argv = process.argv.slice(2)) {
-  const config = parseCliArgs(argv, process.env);
+async function runCli(argv = process.argv.slice(2), runtime = {}) {
+  const env2 = runtime.env ?? process.env;
+  const writeStdout = runtime.writeStdout ?? ((chunk) => {
+    process.stdout.write(chunk);
+  });
+  const parsed = parseCliArgs(argv, env2);
+  if (parsed.kind === "help") {
+    printHelp(writeStdout);
+    return;
+  }
+  if (parsed.kind === "version") {
+    printVersion(writeStdout);
+    return;
+  }
+  const config = parsed;
   const inputs = resolveInputs(config.inputEnv);
   const reporter = new ConsoleReporter();
-  const telemetry = createTelemetryContext({ action: "postman-aws-spec-discovery-action", actionVersion: resolveActionVersion2(), logger: reporter });
-  telemetry.setTeamId(config.inputEnv.POSTMAN_TEAM_ID ?? process.env.POSTMAN_TEAM_ID);
+  const telemetry = createTelemetryContext({
+    action: "postman-aws-spec-discovery-action",
+    actionVersion: resolveActionVersion2(),
+    logger: reporter
+  });
+  telemetry.setTeamId(config.inputEnv.POSTMAN_TEAM_ID ?? env2.POSTMAN_TEAM_ID);
   const { accountType } = await prepareTelemetryCredentials({
-    postmanApiKey: config.inputEnv.INPUT_POSTMAN_API_KEY ?? process.env.POSTMAN_API_KEY,
-    postmanAccessToken: config.inputEnv.INPUT_POSTMAN_ACCESS_TOKEN ?? process.env.POSTMAN_ACCESS_TOKEN
+    postmanApiKey: config.inputEnv.INPUT_POSTMAN_API_KEY ?? env2.POSTMAN_API_KEY,
+    postmanAccessToken: config.inputEnv.INPUT_POSTMAN_ACCESS_TOKEN ?? env2.POSTMAN_ACCESS_TOKEN
   });
   try {
     const result = await execute(inputs, {
@@ -168509,7 +168636,7 @@ async function runCli(argv = process.argv.slice(2)) {
     });
     await writeOptionalFile(config.resultJsonPath, JSON.stringify(result, null, 2));
     await writeOptionalFile(config.dotenvPath, toDotenv(result.outputs));
-    process.stdout.write(`${JSON.stringify(result, null, 2)}
+    writeStdout(`${JSON.stringify(result, null, 2)}
 `);
     telemetry.setAccountType(accountType);
     telemetry.emitCompletion("success");
@@ -168519,9 +168646,24 @@ async function runCli(argv = process.argv.slice(2)) {
     throw error2;
   }
 }
-var currentModulePath = typeof __filename === "string" ? __filename : "";
-var entrypoint = process.argv[1];
-if (entrypoint && currentModulePath === entrypoint) {
+function shouldRunMain() {
+  const cjsModule = typeof module !== "undefined" ? module : void 0;
+  const cjsRequire = typeof require !== "undefined" ? require : void 0;
+  if (cjsModule && cjsRequire && cjsRequire.main === cjsModule) {
+    return true;
+  }
+  const currentModulePath = typeof __filename === "string" ? __filename : "";
+  const entrypointPath = process.argv[1];
+  if (!currentModulePath || !entrypointPath) {
+    return false;
+  }
+  try {
+    return (0, import_node_fs4.realpathSync)(currentModulePath) === (0, import_node_fs4.realpathSync)(entrypointPath);
+  } catch {
+    return import_node_path16.default.resolve(currentModulePath) === import_node_path16.default.resolve(entrypointPath);
+  }
+}
+if (shouldRunMain()) {
   runCli().catch((error2) => {
     const message = formatUserSafeError(error2);
     process.stderr.write(`${message}

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -168733,8 +168733,22 @@ function normalizeInputValue(value) {
   return trimmed ? trimmed : void 0;
 }
 function getInput2(name, env2 = process.env) {
-  const envName = `INPUT_${name.replace(/-/g, "_").toUpperCase()}`;
-  return normalizeInputValue(env2[envName]);
+  const normalizedName = `INPUT_${name.replace(/-/g, "_").toUpperCase()}`;
+  const runnerName = `INPUT_${name.replace(/ /g, "_").toUpperCase()}`;
+  const normalizedRaw = env2[normalizedName];
+  const runnerRaw = runnerName === normalizedName ? void 0 : env2[runnerName];
+  const hasNormalized = normalizedRaw !== void 0;
+  const hasRunner = runnerRaw !== void 0;
+  if (hasNormalized && hasRunner) {
+    const normalizedValue = normalizeInputValue(normalizedRaw);
+    const runnerValue = normalizeInputValue(runnerRaw);
+    if (normalizedValue !== runnerValue) {
+      throw new Error(
+        `Conflicting values for ${name}: ${normalizedName}=${JSON.stringify(normalizedValue)} vs ${runnerName}=${JSON.stringify(runnerValue)}`
+      );
+    }
+  }
+  return normalizeInputValue(hasNormalized ? normalizedRaw : runnerRaw);
 }
 function parseBoolean2(input, inputName, fallback2 = true) {
   if (!input) {
@@ -168749,13 +168763,16 @@ function parseBoolean2(input, inputName, fallback2 = true) {
   }
   throw new Error(`${inputName} must be a boolean-like value, got: ${input}`);
 }
-function parsePositiveInteger(input, inputName, fallback2) {
+function parseBoundedInteger(input, inputName, fallback2, min, max) {
   if (!input) {
     return fallback2;
   }
-  const value = Number.parseInt(input, 10);
-  if (!Number.isFinite(value) || value < 0) {
-    throw new Error(`${inputName} must be a non-negative integer, got: ${input}`);
+  if (!/^\d+$/.test(input)) {
+    throw new Error(`${inputName} must be a non-negative integer between ${min} and ${max}, got: ${input}`);
+  }
+  const value = Number(input);
+  if (!Number.isSafeInteger(value) || value < min || value > max) {
+    throw new Error(`${inputName} must be a non-negative integer between ${min} and ${max}, got: ${input}`);
   }
   return value;
 }
@@ -168801,9 +168818,9 @@ function parseStringArrayJson(raw, inputName) {
 }
 function resolveInputs(env2 = process.env) {
   const mode = parseMode(getInput2("mode", env2) ?? DEFAULT_MODE);
-  const awsRegion = getInput2("aws-region", env2) ?? "";
+  const awsRegion = getInput2("aws-region", env2) ?? normalizeInputValue(env2.AWS_REGION) ?? normalizeInputValue(env2.AWS_DEFAULT_REGION) ?? "";
   if (!awsRegion) {
-    throw new Error("aws-region is required");
+    throw new Error("aws-region is required (set --aws-region / INPUT_AWS_REGION, or AWS_REGION / AWS_DEFAULT_REGION)");
   }
   const repoRoot = getInput2("repo-root", env2) ?? normalizeInputValue(env2.GITHUB_WORKSPACE) ?? normalizeInputValue(env2.CI_PROJECT_DIR) ?? normalizeInputValue(env2.BITBUCKET_CLONE_DIR) ?? normalizeInputValue(env2.BUILD_SOURCESDIRECTORY) ?? DEFAULT_REPO_ROOT;
   const gatewayId = getInput2("gateway-id", env2);
@@ -168855,23 +168872,23 @@ function resolveInputs(env2 = process.env) {
     apiFilter,
     serviceMapping: parseServiceMapping(serviceMappingRaw),
     outputDir,
-    maxCandidates: parsePositiveInteger(maxCandidatesRaw, "max-candidates", 50),
+    maxCandidates: parseBoundedInteger(maxCandidatesRaw, "max-candidates", 50, 1, 1e4),
     dryRun: parseBoolean2(dryRunRaw, "dry-run", false),
     preflightChecks: parseBoolean2(preflightChecksRaw, "preflight-checks", true),
     preflightPermissionProbe: parseBoolean2(preflightPermissionProbeRaw, "preflight-permission-probe", true),
-    requestTimeoutMs: parsePositiveInteger(requestTimeoutMsRaw, "request-timeout-ms", 3e4),
-    maxAttempts: parsePositiveInteger(maxAttemptsRaw, "max-attempts", 3),
+    requestTimeoutMs: parseBoundedInteger(requestTimeoutMsRaw, "request-timeout-ms", 3e4, 1, 3e5),
+    maxAttempts: parseBoundedInteger(maxAttemptsRaw, "max-attempts", 3, 1, 100),
     includeV2: parseBoolean2(includeV2Raw, "include-v2", true)
   };
 }
 function readActionInputs(inputReader) {
-  const requiredRegion = inputReader.getInput("aws-region", { required: true }).trim();
+  const requiredRegion = inputReader.getInput("aws-region").trim();
   return resolveInputs({
-    INPUT_AWS_REGION: requiredRegion,
+    ...process.env,
+    INPUT_AWS_REGION: requiredRegion || void 0,
     INPUT_GATEWAY_ID: normalizeInputValue(inputReader.getInput("gateway-id")),
     INPUT_STAGE: normalizeInputValue(inputReader.getInput("stage")),
-    INPUT_OUTPUT_DIR: normalizeInputValue(inputReader.getInput("output-dir")) ?? actionContract.inputs["output-dir"].default,
-    ...process.env
+    INPUT_OUTPUT_DIR: normalizeInputValue(inputReader.getInput("output-dir")) ?? actionContract.inputs["output-dir"].default
   });
 }
 function resolveLegacyServiceName(gatewayId, gatewayName, tags, serviceMapping) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-aws-spec-discovery",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-aws-spec-discovery",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-aws-spec-discovery",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "description": "Discover AWS-hosted API specs and hand the result to Postman API onboarding.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "prepare": "git config core.hooksPath .githooks",
-    "build": "npm run typecheck && rm -rf dist && esbuild src/index.ts --bundle --platform=node --target=node24 --format=cjs --outfile=dist/index.cjs && esbuild src/cli.ts --bundle --platform=node --target=node24 --format=cjs --banner:js='#!/usr/bin/env node' --outfile=dist/cli.cjs",
+    "build": "npm run typecheck && rm -rf dist && esbuild src/index.ts --bundle --platform=node --target=node24 --format=cjs --outfile=dist/index.cjs && esbuild src/cli.ts --bundle --platform=node --target=node24 --format=cjs --banner:js='#!/usr/bin/env node' --outfile=dist/cli.cjs && chmod 755 dist/cli.cjs",
     "verify:dist": "npm run build && git diff --ignore-space-at-eol --text --exit-code -- dist",
     "docs:tables": "node scripts/render-action-tables.mjs",
     "lint": "eslint .",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -96,10 +96,6 @@ function printVersion(writeStdout: (chunk: string) => void): void {
 }
 
 export function parseCliArgs(argv: string[], env: NodeJS.ProcessEnv = process.env): ParsedCliArgs {
-  const knownInputEnvNames = new Set(CLI_INPUT_NAMES.map((name) => normalizeCliFlag(name)));
-  const knownMetaEnvNames = new Set(['INPUT_RESULT_JSON', 'INPUT_DOTENV_PATH']);
-  const knownEnvNames = new Set([...knownInputEnvNames, ...knownMetaEnvNames]);
-
   const inputEnv: NodeJS.ProcessEnv = { ...env };
   const seen = new Set<string>();
   let command: 'run' | 'help' | 'version' = 'run';
@@ -154,23 +150,19 @@ export function parseCliArgs(argv: string[], env: NodeJS.ProcessEnv = process.en
     }
 
     if (optionName === 'result-json') {
-      const envValue = normalizeInputish(env.INPUT_RESULT_JSON);
-      if (envValue !== undefined && envValue !== rawValue) {
-        throw new Error('Conflicting values for --result-json and INPUT_RESULT_JSON');
-      }
       resultJsonPath = rawValue;
       continue;
     }
     if (optionName === 'dotenv-path') {
-      const envValue = normalizeInputish(env.INPUT_DOTENV_PATH);
-      if (envValue !== undefined && envValue !== rawValue) {
-        throw new Error('Conflicting values for --dotenv-path and INPUT_DOTENV_PATH');
-      }
       dotenvPath = rawValue;
       continue;
     }
 
     const envName = normalizeCliFlag(optionName);
+    const runnerEnvName = `INPUT_${optionName.toUpperCase()}`;
+    if (runnerEnvName !== envName) {
+      delete inputEnv[runnerEnvName];
+    }
     inputEnv[envName] = rawValue;
   }
 
@@ -179,17 +171,6 @@ export function parseCliArgs(argv: string[], env: NodeJS.ProcessEnv = process.en
       throw new Error(`Option --${command} cannot be combined with other options`);
     }
     return { kind: command };
-  }
-
-  for (const key of Object.keys(env)) {
-    if (!key.startsWith('INPUT_')) {
-      continue;
-    }
-    const runnerNormalized = `INPUT_${key.slice('INPUT_'.length).replace(/-/g, '_')}`;
-    if (knownEnvNames.has(key) || knownEnvNames.has(runnerNormalized)) {
-      continue;
-    }
-    throw new Error(`Unknown INPUT alias: ${key}`);
   }
 
   return {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
@@ -12,6 +13,16 @@ interface CliConfig {
   inputEnv: NodeJS.ProcessEnv;
   resultJsonPath: string;
   dotenvPath?: string;
+}
+
+export type ParsedCliArgs =
+  | { kind: 'help' }
+  | { kind: 'version' }
+  | ({ kind: 'run' } & CliConfig);
+
+interface CliRuntime {
+  env?: NodeJS.ProcessEnv;
+  writeStdout?: (chunk: string) => void;
 }
 
 class ConsoleReporter implements ReporterLike {
@@ -29,65 +40,172 @@ class ConsoleReporter implements ReporterLike {
   }
 }
 
-function readFlag(argv: string[], name: string): string | undefined {
-  const prefix = `--${name}=`;
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (arg === `--${name}`) {
-      return argv[index + 1];
-    }
-    if (arg?.startsWith(prefix)) {
-      return arg.slice(prefix.length);
-    }
-  }
-  return undefined;
-}
+const CLI_INPUT_NAMES = [
+  'mode',
+  'aws-region',
+  'gateway-id',
+  'repo-url',
+  'repo-slug',
+  'git-provider',
+  'ref',
+  'sha',
+  'repo-root',
+  'expected-service-name',
+  'expected-gateway-ids-json',
+  'stage',
+  'api-filter',
+  'service-mapping-json',
+  'output-dir',
+  'max-candidates',
+  'dry-run',
+  'preflight-checks',
+  'preflight-permission-probe',
+  'request-timeout-ms',
+  'max-attempts',
+  'include-v2',
+  'postman-api-key',
+  'postman-access-token'
+] as const;
+
+const META_OPTIONS = new Set(['result-json', 'dotenv-path', 'help', 'version']);
+
+const KNOWN_OPTIONS = new Set<string>([...CLI_INPUT_NAMES, ...META_OPTIONS]);
 
 function normalizeCliFlag(name: string): string {
   return `INPUT_${name.replace(/-/g, '_').toUpperCase()}`;
 }
 
-export function parseCliArgs(argv: string[], env: NodeJS.ProcessEnv = process.env): CliConfig {
-  const inputNames = [
-    'mode',
-    'aws-region',
-    'gateway-id',
-    'repo-url',
-    'repo-slug',
-    'git-provider',
-    'ref',
-    'sha',
-    'repo-root',
-    'expected-service-name',
-    'expected-gateway-ids-json',
-    'stage',
-    'api-filter',
-    'service-mapping-json',
-    'output-dir',
-    'max-candidates',
-    'dry-run',
-    'preflight-checks',
-    'preflight-permission-probe',
-    'request-timeout-ms',
-    'max-attempts',
-    'include-v2',
-    'postman-api-key',
-    'postman-access-token'
-  ];
+function printHelp(writeStdout: (chunk: string) => void): void {
+  writeStdout(`Usage: postman-aws-spec-discovery [options]
+
+Discover AWS-hosted API specs and emit JSON / dotenv artifacts for downstream
+Postman onboarding steps.
+
+Options mirror action inputs as --kebab-case flags (for example --aws-region,
+--dry-run, --output-dir). Additional CLI-only options:
+
+  --result-json <path>   Write the full result JSON (default: postman-aws-spec-discovery-result.json)
+  --dotenv-path <path>   Optional dotenv export for downstream jobs
+  --help                 Show this help text and exit
+  --version              Print the package version and exit
+`);
+}
+
+function printVersion(writeStdout: (chunk: string) => void): void {
+  writeStdout(`${resolveActionVersion()}\n`);
+}
+
+export function parseCliArgs(argv: string[], env: NodeJS.ProcessEnv = process.env): ParsedCliArgs {
+  const knownInputEnvNames = new Set(CLI_INPUT_NAMES.map((name) => normalizeCliFlag(name)));
+  const knownMetaEnvNames = new Set(['INPUT_RESULT_JSON', 'INPUT_DOTENV_PATH']);
+  const knownEnvNames = new Set([...knownInputEnvNames, ...knownMetaEnvNames]);
 
   const inputEnv: NodeJS.ProcessEnv = { ...env };
-  for (const name of inputNames) {
-    const value = readFlag(argv, name);
-    if (value !== undefined) {
-      inputEnv[normalizeCliFlag(name)] = value;
+  const seen = new Set<string>();
+  let command: 'run' | 'help' | 'version' = 'run';
+  let resultJsonPath = normalizeInputish(env.INPUT_RESULT_JSON) ?? 'postman-aws-spec-discovery-result.json';
+  let dotenvPath = normalizeInputish(env.INPUT_DOTENV_PATH);
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token) {
+      continue;
     }
+
+    if (!token.startsWith('--')) {
+      throw new Error(`Unexpected positional argument: ${token}`);
+    }
+
+    const raw = token.slice(2);
+    const equalsIndex = raw.indexOf('=');
+    const optionName = equalsIndex >= 0 ? raw.slice(0, equalsIndex) : raw;
+
+    if (!optionName || !KNOWN_OPTIONS.has(optionName)) {
+      throw new Error(`Unknown option: --${optionName || raw}`);
+    }
+
+    if (seen.has(optionName)) {
+      throw new Error(`Duplicate option: --${optionName}`);
+    }
+    seen.add(optionName);
+
+    if (optionName === 'help' || optionName === 'version') {
+      if (equalsIndex >= 0) {
+        throw new Error(`Option --${optionName} does not accept a value`);
+      }
+      command = optionName;
+      continue;
+    }
+
+    let rawValue: string | undefined;
+    if (equalsIndex >= 0) {
+      rawValue = raw.slice(equalsIndex + 1);
+    } else {
+      const next = argv[index + 1];
+      if (next !== undefined && !next.startsWith('--')) {
+        rawValue = next;
+        index += 1;
+      } else {
+        throw new Error(`Missing value for --${optionName}`);
+      }
+    }
+    if (rawValue === '') {
+      throw new Error(`Missing value for --${optionName}`);
+    }
+
+    if (optionName === 'result-json') {
+      const envValue = normalizeInputish(env.INPUT_RESULT_JSON);
+      if (envValue !== undefined && envValue !== rawValue) {
+        throw new Error('Conflicting values for --result-json and INPUT_RESULT_JSON');
+      }
+      resultJsonPath = rawValue;
+      continue;
+    }
+    if (optionName === 'dotenv-path') {
+      const envValue = normalizeInputish(env.INPUT_DOTENV_PATH);
+      if (envValue !== undefined && envValue !== rawValue) {
+        throw new Error('Conflicting values for --dotenv-path and INPUT_DOTENV_PATH');
+      }
+      dotenvPath = rawValue;
+      continue;
+    }
+
+    const envName = normalizeCliFlag(optionName);
+    inputEnv[envName] = rawValue;
+  }
+
+  if (command !== 'run') {
+    if (seen.size !== 1) {
+      throw new Error(`Option --${command} cannot be combined with other options`);
+    }
+    return { kind: command };
+  }
+
+  for (const key of Object.keys(env)) {
+    if (!key.startsWith('INPUT_')) {
+      continue;
+    }
+    const runnerNormalized = `INPUT_${key.slice('INPUT_'.length).replace(/-/g, '_')}`;
+    if (knownEnvNames.has(key) || knownEnvNames.has(runnerNormalized)) {
+      continue;
+    }
+    throw new Error(`Unknown INPUT alias: ${key}`);
   }
 
   return {
+    kind: 'run',
     inputEnv,
-    resultJsonPath: readFlag(argv, 'result-json') ?? 'postman-aws-spec-discovery-result.json',
-    dotenvPath: readFlag(argv, 'dotenv-path')
+    resultJsonPath,
+    dotenvPath
   };
+}
+
+function normalizeInputish(value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
 }
 
 export function toDotenv(outputs: Record<string, string>): string {
@@ -134,17 +252,39 @@ async function writeOptionalFile(filePath: string | undefined, content: string):
   await writeFile(resolved, content, 'utf8');
 }
 
-export async function runCli(argv: string[] = process.argv.slice(2)): Promise<void> {
-  const config = parseCliArgs(argv, process.env);
+export async function runCli(
+  argv: string[] = process.argv.slice(2),
+  runtime: CliRuntime = {}
+): Promise<void> {
+  const env = runtime.env ?? process.env;
+  const writeStdout = runtime.writeStdout ?? ((chunk: string) => {
+    process.stdout.write(chunk);
+  });
+  const parsed = parseCliArgs(argv, env);
+
+  if (parsed.kind === 'help') {
+    printHelp(writeStdout);
+    return;
+  }
+  if (parsed.kind === 'version') {
+    printVersion(writeStdout);
+    return;
+  }
+
+  const config = parsed;
   const inputs = resolveInputs(config.inputEnv);
   const reporter = new ConsoleReporter();
-  const telemetry = createTelemetryContext({ action: 'postman-aws-spec-discovery-action', actionVersion: resolveActionVersion(), logger: reporter });
-  telemetry.setTeamId(config.inputEnv.POSTMAN_TEAM_ID ?? process.env.POSTMAN_TEAM_ID);
+  const telemetry = createTelemetryContext({
+    action: 'postman-aws-spec-discovery-action',
+    actionVersion: resolveActionVersion(),
+    logger: reporter
+  });
+  telemetry.setTeamId(config.inputEnv.POSTMAN_TEAM_ID ?? env.POSTMAN_TEAM_ID);
   // Optional telemetry enrichment (D1): mint/re-mint access token when PMAK is
   // present, resolve account_type once, best-effort, before either completion emit.
   const { accountType } = await prepareTelemetryCredentials({
-    postmanApiKey: config.inputEnv.INPUT_POSTMAN_API_KEY ?? process.env.POSTMAN_API_KEY,
-    postmanAccessToken: config.inputEnv.INPUT_POSTMAN_ACCESS_TOKEN ?? process.env.POSTMAN_ACCESS_TOKEN
+    postmanApiKey: config.inputEnv.INPUT_POSTMAN_API_KEY ?? env.POSTMAN_API_KEY,
+    postmanAccessToken: config.inputEnv.INPUT_POSTMAN_ACCESS_TOKEN ?? env.POSTMAN_ACCESS_TOKEN
   });
   try {
     const result = await execute(inputs, {
@@ -159,7 +299,7 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<vo
     await writeOptionalFile(config.resultJsonPath, JSON.stringify(result, null, 2));
     await writeOptionalFile(config.dotenvPath, toDotenv(result.outputs));
 
-    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    writeStdout(`${JSON.stringify(result, null, 2)}\n`);
     telemetry.setAccountType(accountType);
     telemetry.emitCompletion('success');
   } catch (error) {
@@ -169,10 +309,26 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<vo
   }
 }
 
-const currentModulePath = typeof __filename === 'string' ? __filename : '';
-const entrypoint = process.argv[1];
+function shouldRunMain(): boolean {
+  const cjsModule = typeof module !== 'undefined' ? module : undefined;
+  const cjsRequire = typeof require !== 'undefined' ? require : undefined;
+  if (cjsModule && cjsRequire && cjsRequire.main === cjsModule) {
+    return true;
+  }
 
-if (entrypoint && currentModulePath === entrypoint) {
+  const currentModulePath = typeof __filename === 'string' ? __filename : '';
+  const entrypointPath = process.argv[1];
+  if (!currentModulePath || !entrypointPath) {
+    return false;
+  }
+  try {
+    return realpathSync(currentModulePath) === realpathSync(entrypointPath);
+  } catch {
+    return path.resolve(currentModulePath) === path.resolve(entrypointPath);
+  }
+}
+
+if (shouldRunMain()) {
   runCli().catch((error) => {
     const message = formatUserSafeError(error);
     process.stderr.write(`${message}\n`);

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -170,8 +170,24 @@ function normalizeInputValue(value: string | undefined): string | undefined {
 }
 
 export function getInput(name: string, env: NodeJS.ProcessEnv = process.env): string | undefined {
-  const envName = `INPUT_${name.replace(/-/g, '_').toUpperCase()}`;
-  return normalizeInputValue(env[envName]);
+  const normalizedName = `INPUT_${name.replace(/-/g, '_').toUpperCase()}`;
+  const runnerName = `INPUT_${name.replace(/ /g, '_').toUpperCase()}`;
+  const normalizedRaw = env[normalizedName];
+  const runnerRaw = runnerName === normalizedName ? undefined : env[runnerName];
+  const hasNormalized = normalizedRaw !== undefined;
+  const hasRunner = runnerRaw !== undefined;
+
+  if (hasNormalized && hasRunner) {
+    const normalizedValue = normalizeInputValue(normalizedRaw);
+    const runnerValue = normalizeInputValue(runnerRaw);
+    if (normalizedValue !== runnerValue) {
+      throw new Error(
+        `Conflicting values for ${name}: ${normalizedName}=${JSON.stringify(normalizedValue)} vs ${runnerName}=${JSON.stringify(runnerValue)}`
+      );
+    }
+  }
+
+  return normalizeInputValue(hasNormalized ? normalizedRaw : runnerRaw);
 }
 
 function parseBoolean(input: string | undefined, inputName: string, fallback = true): boolean {
@@ -188,13 +204,22 @@ function parseBoolean(input: string | undefined, inputName: string, fallback = t
   throw new Error(`${inputName} must be a boolean-like value, got: ${input}`);
 }
 
-function parsePositiveInteger(input: string | undefined, inputName: string, fallback: number): number {
+function parseBoundedInteger(
+  input: string | undefined,
+  inputName: string,
+  fallback: number,
+  min: number,
+  max: number
+): number {
   if (!input) {
     return fallback;
   }
-  const value = Number.parseInt(input, 10);
-  if (!Number.isFinite(value) || value < 0) {
-    throw new Error(`${inputName} must be a non-negative integer, got: ${input}`);
+  if (!/^\d+$/.test(input)) {
+    throw new Error(`${inputName} must be a non-negative integer between ${min} and ${max}, got: ${input}`);
+  }
+  const value = Number(input);
+  if (!Number.isSafeInteger(value) || value < min || value > max) {
+    throw new Error(`${inputName} must be a non-negative integer between ${min} and ${max}, got: ${input}`);
   }
   return value;
 }
@@ -244,9 +269,13 @@ function parseStringArrayJson(raw: string, inputName: string): string[] {
 
 export function resolveInputs(env: NodeJS.ProcessEnv = process.env): ResolvedInputs {
   const mode = parseMode(getInput('mode', env) ?? DEFAULT_MODE);
-  const awsRegion = getInput('aws-region', env) ?? '';
+  const awsRegion =
+    getInput('aws-region', env) ??
+    normalizeInputValue(env.AWS_REGION) ??
+    normalizeInputValue(env.AWS_DEFAULT_REGION) ??
+    '';
   if (!awsRegion) {
-    throw new Error('aws-region is required');
+    throw new Error('aws-region is required (set --aws-region / INPUT_AWS_REGION, or AWS_REGION / AWS_DEFAULT_REGION)');
   }
   const repoRoot =
     getInput('repo-root', env) ??
@@ -307,24 +336,24 @@ export function resolveInputs(env: NodeJS.ProcessEnv = process.env): ResolvedInp
     apiFilter,
     serviceMapping: parseServiceMapping(serviceMappingRaw),
     outputDir,
-    maxCandidates: parsePositiveInteger(maxCandidatesRaw, 'max-candidates', 50),
+    maxCandidates: parseBoundedInteger(maxCandidatesRaw, 'max-candidates', 50, 1, 10000),
     dryRun: parseBoolean(dryRunRaw, 'dry-run', false),
     preflightChecks: parseBoolean(preflightChecksRaw, 'preflight-checks', true),
     preflightPermissionProbe: parseBoolean(preflightPermissionProbeRaw, 'preflight-permission-probe', true),
-    requestTimeoutMs: parsePositiveInteger(requestTimeoutMsRaw, 'request-timeout-ms', 30000),
-    maxAttempts: parsePositiveInteger(maxAttemptsRaw, 'max-attempts', 3),
+    requestTimeoutMs: parseBoundedInteger(requestTimeoutMsRaw, 'request-timeout-ms', 30000, 1, 300000),
+    maxAttempts: parseBoundedInteger(maxAttemptsRaw, 'max-attempts', 3, 1, 100),
     includeV2: parseBoolean(includeV2Raw, 'include-v2', true)
   };
 }
 
 export function readActionInputs(inputReader: InputReaderLike): ResolvedInputs {
-  const requiredRegion = inputReader.getInput('aws-region', { required: true }).trim();
+  const requiredRegion = inputReader.getInput('aws-region').trim();
   return resolveInputs({
-    INPUT_AWS_REGION: requiredRegion,
+    ...process.env,
+    INPUT_AWS_REGION: requiredRegion || undefined,
     INPUT_GATEWAY_ID: normalizeInputValue(inputReader.getInput('gateway-id')),
     INPUT_STAGE: normalizeInputValue(inputReader.getInput('stage')),
-    INPUT_OUTPUT_DIR: normalizeInputValue(inputReader.getInput('output-dir')) ?? actionContract.inputs['output-dir'].default,
-    ...process.env
+    INPUT_OUTPUT_DIR: normalizeInputValue(inputReader.getInput('output-dir')) ?? actionContract.inputs['output-dir'].default
   });
 }
 

--- a/tests/cli-packaging.test.ts
+++ b/tests/cli-packaging.test.ts
@@ -1,0 +1,159 @@
+import { execFile, spawnSync } from 'node:child_process';
+import { access, constants, lstat, mkdir, mkdtemp, readFile, rm, stat, symlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe('CLI packaging contract', () => {
+  it('commits a Node shebang and executable mode on dist/cli.cjs', async () => {
+    const cliPath = path.join(repoRoot, 'dist', 'cli.cjs');
+    const contents = await readFile(cliPath, 'utf8');
+    expect(contents.startsWith('#!/usr/bin/env node\n')).toBe(true);
+
+    const mode = (await stat(cliPath)).mode & 0o777;
+    expect(mode & 0o111).not.toBe(0);
+    await access(cliPath, constants.X_OK);
+  });
+
+  it('packs, installs, and runs .bin --help via symlink invocation', async () => {
+    const packDir = await makeTempDir('postman-aws-spec-pack-');
+    const prefixDir = await makeTempDir('postman-aws-spec-prefix-');
+
+    const packResult = await execFileAsync(
+      'npm',
+      ['pack', '--json', '--pack-destination', packDir],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        env: {
+          NPM_CONFIG_CACHE: path.join(packDir, '.npm-cache'),
+          PATH: process.env.PATH ?? ''
+        },
+        maxBuffer: 20 * 1024 * 1024
+      }
+    );
+    const [packed] = JSON.parse(packResult.stdout) as Array<{
+      filename: string;
+      name: string;
+    }>;
+    expect(packed.name).toBe('@postman-cse/onboarding-aws-spec-discovery');
+
+    const tarballPath = path.join(packDir, packed.filename);
+    await mkdir(prefixDir, { recursive: true });
+    await execFileAsync('npm', ['install', '--prefix', prefixDir, tarballPath], {
+      encoding: 'utf8',
+      env: {
+        NPM_CONFIG_CACHE: path.join(packDir, '.npm-cache'),
+        PATH: process.env.PATH ?? ''
+      },
+      maxBuffer: 20 * 1024 * 1024
+    });
+
+    const binPath = path.join(
+      prefixDir,
+      'node_modules',
+      '.bin',
+      process.platform === 'win32' ? 'postman-aws-spec-discovery.cmd' : 'postman-aws-spec-discovery'
+    );
+
+    if (process.platform !== 'win32') {
+      const binStat = await lstat(binPath);
+      expect(binStat.isSymbolicLink() || binStat.isFile()).toBe(true);
+    }
+
+    const help = await execFileAsync(binPath, ['--help'], {
+      encoding: 'utf8',
+      env: {
+        PATH: process.env.PATH ?? '',
+        INPUT_AWS_REGION: '',
+        AWS_REGION: '',
+        AWS_DEFAULT_REGION: '',
+        INPUT_POSTMAN_API_KEY: '',
+        POSTMAN_API_KEY: ''
+      },
+      maxBuffer: 1024 * 1024
+    });
+
+    expect(help.stdout).toMatch(/Usage:\s+postman-aws-spec-discovery/i);
+    expect(help.stderr).not.toMatch(/permission denied|exec format|syntax error|unexpected token|"use strict"/i);
+    expect(help.stdout).not.toMatch(/"use strict"/);
+
+    const version = await execFileAsync(binPath, ['--version'], {
+      encoding: 'utf8',
+      env: { PATH: process.env.PATH ?? '' },
+      maxBuffer: 1024 * 1024
+    });
+    const packageJson = JSON.parse(await readFile(path.join(repoRoot, 'package.json'), 'utf8')) as {
+      version: string;
+    };
+    expect(version.stdout.trim()).toBe(packageJson.version);
+
+    if (process.platform !== 'win32') {
+      const symlinkDir = await makeTempDir('postman-aws-spec-symlink-');
+      const symlinkPath = path.join(symlinkDir, 'postman-aws-spec-discovery');
+      const installedCli = path.join(
+        prefixDir,
+        'node_modules',
+        '@postman-cse',
+        'onboarding-aws-spec-discovery',
+        'dist',
+        'cli.cjs'
+      );
+      await symlink(installedCli, symlinkPath);
+      const symlinkHelp = spawnSync(symlinkPath, ['--help'], {
+        encoding: 'utf8',
+        env: { PATH: process.env.PATH ?? '' }
+      });
+      expect(symlinkHelp.status).toBe(0);
+      expect(symlinkHelp.stdout).toMatch(/Usage:\s+postman-aws-spec-discovery/i);
+    }
+  }, 120000);
+
+  it('runs the direct dist/cli.cjs artifact with a shebang path', async () => {
+    const cliPath = path.join(repoRoot, 'dist', 'cli.cjs');
+    const help = await execFileAsync(cliPath, ['--help'], {
+      encoding: 'utf8',
+      env: { PATH: process.env.PATH ?? '' },
+      maxBuffer: 1024 * 1024
+    });
+    expect(help.stdout).toMatch(/Usage:\s+postman-aws-spec-discovery/i);
+  }, 20000);
+
+  it('runs node dist/cli.cjs --help', async () => {
+    const cliPath = path.join(repoRoot, 'dist', 'cli.cjs');
+    const help = await execFileAsync(process.execPath, [cliPath, '--help'], {
+      encoding: 'utf8',
+      env: { PATH: process.env.PATH ?? '' },
+      maxBuffer: 1024 * 1024
+    });
+    expect(help.stdout).toMatch(/Usage:\s+postman-aws-spec-discovery/i);
+  }, 20000);
+
+  it('does not auto-run when dist/cli.cjs is imported', async () => {
+    const cliPath = path.join(repoRoot, 'dist', 'cli.cjs');
+    const imported = await execFileAsync(process.execPath, ['-e', `require(${JSON.stringify(cliPath)})`], {
+      encoding: 'utf8',
+      env: { PATH: process.env.PATH ?? '' },
+      maxBuffer: 1024 * 1024
+    });
+    expect(imported.stdout).toBe('');
+    expect(imported.stderr).toBe('');
+  }, 20000);
+});

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -69,7 +69,7 @@ describe('runCli integration boundary', () => {
 
   it.each([
     ['--help', /Usage: postman-aws-spec-discovery/],
-    ['--version', /^2\.0\.0\n$/]
+    ['--version', /^\d+\.\d+\.\d+\n$/]
   ])('handles %s without resolving inputs, telemetry, execution, or files', async (flag, expected) => {
     const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     await runCli([flag], { writeStdout: (chunk) => process.stdout.write(chunk) });

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -33,13 +33,31 @@ describe('parseCliArgs', () => {
     expect(() => parseCliArgs(['--help', '--version'], {})).toThrow(/cannot be combined/);
   });
 
-  it('lets explicit CLI values override normalized INPUT environment values', () => {
-    const parsed = parseCliArgs(['--dry-run', 'false'], { INPUT_DRY_RUN: 'true' });
+  it('lets explicit CLI values override normalized and runner-form INPUT environment values', () => {
+    const parsed = parseCliArgs(['--dry-run', 'false'], {
+      INPUT_DRY_RUN: 'true',
+      'INPUT_DRY-RUN': 'not-a-boolean'
+    } as NodeJS.ProcessEnv);
     expect(parsed.kind).toBe('run');
     if (parsed.kind !== 'run') {
       return;
     }
     expect(parsed.inputEnv.INPUT_DRY_RUN).toBe('false');
+    expect(parsed.inputEnv['INPUT_DRY-RUN']).toBeUndefined();
+  });
+
+  it('preserves unrelated ambient INPUT_* variables from wrappers', () => {
+    const parsed = parseCliArgs(['--aws-region', 'us-east-1'], {
+      INPUT_COMPOSITE_MODE: 'publish',
+      'INPUT_WRAPPER-FLAG': 'unexpected'
+    } as NodeJS.ProcessEnv);
+    expect(parsed.kind).toBe('run');
+    if (parsed.kind !== 'run') {
+      return;
+    }
+    expect(parsed.inputEnv.INPUT_COMPOSITE_MODE).toBe('publish');
+    expect(parsed.inputEnv['INPUT_WRAPPER-FLAG']).toBe('unexpected');
+    expect(parsed.inputEnv.INPUT_AWS_REGION).toBe('us-east-1');
   });
 });
 

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -20,12 +20,65 @@ vi.mock('../src/lib/aws/client.js', () => ({
   }
 }));
 
-import { runCli } from '../src/cli.js';
+import { parseCliArgs, runCli } from '../src/cli.js';
+
+describe('parseCliArgs', () => {
+  it('rejects unknown, positional, missing, and duplicate arguments', () => {
+    expect(() => parseCliArgs(['--unknown', 'value'], {})).toThrow(/Unknown option: --unknown/);
+    expect(() => parseCliArgs(['us-east-1'], {})).toThrow(/Unexpected positional argument/);
+    expect(() => parseCliArgs(['--aws-region'], {})).toThrow(/Missing value for --aws-region/);
+    expect(() => parseCliArgs(['--aws-region', '--dry-run', 'true'], {})).toThrow(/Missing value for --aws-region/);
+    expect(() => parseCliArgs(['--dry-run'], {})).toThrow(/Missing value for --dry-run/);
+    expect(() => parseCliArgs(['--dry-run=false', '--dry-run', 'true'], {})).toThrow(/Duplicate option: --dry-run/);
+    expect(() => parseCliArgs(['--help', '--version'], {})).toThrow(/cannot be combined/);
+  });
+
+  it('lets explicit CLI values override normalized INPUT environment values', () => {
+    const parsed = parseCliArgs(['--dry-run', 'false'], { INPUT_DRY_RUN: 'true' });
+    expect(parsed.kind).toBe('run');
+    if (parsed.kind !== 'run') {
+      return;
+    }
+    expect(parsed.inputEnv.INPUT_DRY_RUN).toBe('false');
+  });
+});
 
 describe('runCli integration boundary', () => {
   beforeEach(() => {
     executeMock.mockReset();
     resolveInputsMock.mockReset();
+  });
+
+  it.each([
+    ['--help', /Usage: postman-aws-spec-discovery/],
+    ['--version', /^2\.0\.0\n$/]
+  ])('handles %s without resolving inputs, telemetry, execution, or files', async (flag, expected) => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runCli([flag], { writeStdout: (chunk) => process.stdout.write(chunk) });
+
+    expect(stdout.mock.calls.map(([chunk]) => String(chunk)).join('')).toMatch(expected);
+    expect(resolveInputsMock).not.toHaveBeenCalled();
+    expect(executeMock).not.toHaveBeenCalled();
+    stdout.mockRestore();
+  });
+
+  it('ignores malformed input environment when printing help', async () => {
+    let stdout = '';
+    await runCli(['--help'], {
+      env: { INPUT_UNKNOWN: 'value', INPUT_DRY_RUN: 'not-a-boolean' },
+      writeStdout: (chunk) => {
+        stdout += chunk;
+      }
+    });
+    expect(stdout).toContain('Usage: postman-aws-spec-discovery');
+    expect(resolveInputsMock).not.toHaveBeenCalled();
+    expect(executeMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed dry-run before input resolution or execution', async () => {
+    await expect(runCli(['--dry-run'])).rejects.toThrow(/Missing value for --dry-run/);
+    expect(resolveInputsMock).not.toHaveBeenCalled();
+    expect(executeMock).not.toHaveBeenCalled();
   });
 
   it('writes result JSON and dotenv artifacts', async () => {

--- a/tests/discovery.test.ts
+++ b/tests/discovery.test.ts
@@ -117,6 +117,54 @@ describe('input parsing', () => {
     ).toThrow(/include-v2 must be a boolean-like value/);
   });
 
+  it('resolves AWS region by input, AWS_REGION, then AWS_DEFAULT_REGION', () => {
+    expect(resolveInputs({ INPUT_AWS_REGION: 'input-region', AWS_REGION: 'aws-region', AWS_DEFAULT_REGION: 'default-region' }).awsRegion).toBe(
+      'input-region'
+    );
+    expect(resolveInputs({ AWS_REGION: 'aws-region', AWS_DEFAULT_REGION: 'default-region' }).awsRegion).toBe('aws-region');
+    expect(resolveInputs({ AWS_DEFAULT_REGION: 'default-region' }).awsRegion).toBe('default-region');
+    expect(() => resolveInputs({})).toThrow(/aws-region is required/);
+  });
+
+  it('accepts runner-form INPUT aliases and rejects conflicting alias values', () => {
+    expect(resolveInputs({ INPUT_AWS_REGION: 'us-east-1', 'INPUT_DRY-RUN': 'true' } as NodeJS.ProcessEnv).dryRun).toBe(true);
+    expect(() =>
+      resolveInputs({
+        INPUT_AWS_REGION: 'us-east-1',
+        INPUT_DRY_RUN: 'false',
+        'INPUT_DRY-RUN': 'true'
+      } as NodeJS.ProcessEnv)
+    ).toThrow(/Conflicting values for dry-run/);
+    expect(() =>
+      resolveInputs({ INPUT_AWS_REGION: 'us-east-1', 'INPUT_DRY-RUN': 'not-a-boolean' } as NodeJS.ProcessEnv)
+    ).toThrow(/dry-run must be a boolean-like value/);
+  });
+
+  it.each([
+    ['INPUT_MAX_CANDIDATES', '10items', 'max-candidates'],
+    ['INPUT_MAX_CANDIDATES', '10001', 'max-candidates'],
+    ['INPUT_REQUEST_TIMEOUT_MS', '1.5', 'request-timeout-ms'],
+    ['INPUT_REQUEST_TIMEOUT_MS', '300001', 'request-timeout-ms'],
+    ['INPUT_MAX_ATTEMPTS', '+3', 'max-attempts'],
+    ['INPUT_MAX_ATTEMPTS', '101', 'max-attempts']
+  ])('rejects non-full-string or out-of-bounds numeric %s=%s', (envName, value, inputName) => {
+    expect(() => resolveInputs({ INPUT_AWS_REGION: 'us-east-1', [envName]: value })).toThrow(
+      new RegExp(`${inputName} must be a non-negative integer between`)
+    );
+  });
+
+  it('accepts bounded integer controls', () => {
+    const inputs = resolveInputs({
+      INPUT_AWS_REGION: 'us-east-1',
+      INPUT_MAX_CANDIDATES: '10000',
+      INPUT_REQUEST_TIMEOUT_MS: '300000',
+      INPUT_MAX_ATTEMPTS: '100'
+    });
+    expect(inputs.maxCandidates).toBe(10000);
+    expect(inputs.requestTimeoutMs).toBe(300000);
+    expect(inputs.maxAttempts).toBe(100);
+  });
+
   it('auto-resolves repo-root from CI workspace variables when omitted', () => {
     const inputs = resolveInputs({
       INPUT_MODE: 'resolve-one',
@@ -2364,6 +2412,10 @@ describe('hardening helpers', () => {
   it('parses CLI flags into action-style input env', () => {
     const parsed = parseCliArgs(['--aws-region', 'us-east-1', '--repo-root', '/tmp/repo', '--result-json', '/tmp/out.json']);
 
+    expect(parsed.kind).toBe('run');
+    if (parsed.kind !== 'run') {
+      return;
+    }
     expect(parsed.inputEnv.INPUT_AWS_REGION).toBe('us-east-1');
     expect(parsed.inputEnv.INPUT_REPO_ROOT).toBe('/tmp/repo');
     expect(parsed.resultJsonPath).toBe('/tmp/out.json');


### PR DESCRIPTION
## Summary
- preserve the exact tested tree from #29 in one squashed conventional commit
- make the installed CommonJS CLI symlink-safe while preserving import-without-auto-run and executable shebang behavior
- make help/version side-effect-free and reject malformed CLI/input forms before execution
- enforce AWS region precedence and bounded full-string numeric parsing
- cover npm pack/install, .bin symlink, direct executable, node-dist, and import safety

## Validation
- replacement tree exactly matches the head tree from #29
- npm test (403 tests)
- npm run typecheck
- npm run lint
- npm run build
- npm run verify:dist
- npx commitlint --from origin/main --to HEAD

## Deferred
- path allocation and atomic publication
- symlink sandbox hardening