### PR TITLE
feat(ci): fast-loop e2e tune-up (P1/P5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Bundle once before fan-out so pack tests and the dist assert only read
+      # dist/. Typecheck stays in the fan-out so it runs exactly once.
+      - run: npm run bundle
       # All checks run in parallel as backgrounded shell processes on one runner,
       # so wall-clock is max(gate), not sum, and setup/npm-ci run once. Failures
       # aggregate under ::group:: logs, so one pass shows every result.
@@ -42,7 +45,7 @@ jobs:
           run lint       npm run lint
           run typecheck  npm run typecheck
           run test       npm test
-          run dist       npm run verify:dist
+          run dist       npm run verify:dist:assert
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             run commitlint npx commitlint \
               --from "${{ github.event.pull_request.base.sha }}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      npm_publish: ${{ steps.release_tag.outputs.npm_publish }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
@@ -101,3 +103,27 @@ jobs:
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           files: release.tgz
+
+  advance-major-alias:
+    # Keep the rolling major alias (e.g. v2) pointing at the newest published
+    # release so consumers pinned to the alias pick it up automatically.
+    # GITHUB_TOKEN pushes do not re-trigger workflows, so moving the alias
+    # here cannot recurse into another Release run.
+    needs: release
+    if: ${{ needs.release.outputs.npm_publish == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Force-move rolling major alias tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          MAJOR="v${VERSION%%.*}"
+          if [ "$MAJOR" = "v$VERSION" ]; then
+            echo "::notice::Tag $GITHUB_REF_NAME is already a major alias; nothing to move."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          COMMIT="$(git rev-parse "HEAD^{commit}")"
+          git tag -fa "$MAJOR" -m "Rolling $MAJOR alias -> $GITHUB_REF_NAME" "$COMMIT"
+          git push origin "$MAJOR" --force

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # postman-aws-spec-discovery-action
 
-Zero-config AWS API spec discovery. Probes IAM permissions to auto-detect available providers, scans repo for IaC signals, resolves the best spec source, and exports it. Supports 8 AWS providers. Dual entry: GitHub Action and CLI.
+Zero-config AWS API spec discovery. Probes IAM permissions to auto-detect available providers, scans repo for IaC signals, resolves best spec source, and exports it. Supports 8 AWS providers. Dual entry: GitHub Action and CLI.
 
 ## Structure
 
@@ -50,13 +50,14 @@ discovered-specs/        # Sample output from discovery runs
 
 ```bash
 npm ci && npm test && npm run typecheck && npm run build
-npm run verify:dist  # CI/hook gate: rebuild + git diff (dev runs build)
+npm run verify:dist:assert  # read-only artifact + git diff (CI after one bundle)
+npm run verify:dist         # rebuild + diff + assert (pre-push / release)
 ```
 
 ## Discovery Flow
 
 1. **Preflight**: Validate AWS credentials via `sts:GetCallerIdentity`
-2. **Provider probing**: Each provider does a lightweight IAM probe; silently skip if denied
+2. **Provider probing**: Each provider does lightweight IAM probe; silently skip if denied
 3. **Repo scanning**: Fingerprint IaC files for provider hints and existing spec files
 4. **Progressive narrowing** (API Gateway): IaC refs -> CFN stacks -> tag filtering -> naming heuristic -> full enumeration
 5. **SNS resolution** (when SNS signals present): 9-level precedence chain (repo-local -> generated artifacts -> SSM -> remote URLs -> EventBridge-derived -> code-derived -> manual-review), subscription enrichment, metadata and webhook sidecar generation
@@ -81,17 +82,20 @@ npm run verify:dist  # CI/hook gate: rebuild + git diff (dev runs build)
 
 ## Gotchas
 
-- `runtime.ts` contains the real execution logic; `index.ts` is just the GitHub Action shell
-- In tests, a custom `createAwsClient` injection builds a minimal registry with only API Gateway to avoid real AWS probes
+- Never commit AWS credentials, Postman tokens, or other secrets; mask before logging
+- `runtime.ts` contains real execution logic; `index.ts` is just GitHub Action shell
+- In tests, custom `createAwsClient` injection builds minimal registry with only API Gateway to avoid real AWS probes
 - Output path is sandboxed: must resolve within `repo-root` (path escapes are blocked)
 - `overrides.undici` in package.json pins undici >=6.24.0 for Node 20 fetch compatibility
 - SSM provider fetches URLs only over HTTPS; non-HTTPS URLs are preserved as pointer artifacts
 
 ## CI
 
-`.github/workflows/ci.yml` runs a single `gate` job that fans out lint, typecheck, test, dist, and commitlint
+`.github/workflows/ci.yml` runs `npm run bundle` once, then single `gate` job
+fans out lint, typecheck, test, read-only `verify:dist:assert`, and commitlint
 as backgrounded shell processes on one runner: wall-clock is `max(gate)`, not
 `sum`, setup runs once, and every gate prints its result under a `::group::`
-block even when another fails.
+block even when another fails. Building before fan-out prevents pack tests from
+racing an in-gate `rm -rf dist` rebuild.
 
-See the workspace `docs/CI.md` for the shared rationale.
+See workspace-root `../../docs/CI.md` for shared rationale.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ npm run build       # Bundle to dist/ (esbuild)
 
 ### Rebuilding dist/
 
-This action ships bundled JavaScript in `dist/`. After any source change, run `npm run build` and include the updated `dist/` files in your commit. CI enforces this with a dedicated `check-dist` job (`npm run verify:dist`), and a pre-push hook rebuilds and stages `dist/` for you.
+This action ships bundled JavaScript in `dist/`. After any source change, run `npm run build` and include the updated `dist/` files in your commit. CI bundles once then runs read-only `npm run verify:dist:assert`; the pre-push hook uses `npm run verify:dist` (rebuild + diff + assert).
 
 ## Release E2E Status
 

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -6,9 +6,9 @@ Git tags and GitHub releases are the public release identifiers for this action.
 
 ## Tag policy
 
-- Immutable releases use `v1.x.y` tags.
-- The rolling `v1` alias moves to the latest compatible `v1.x.y` release.
-- Existing release tags are never force-pushed or rewritten.
+- Immutable releases use `vMAJOR.MINOR.PATCH` tags.
+- The rolling major alias (`vMAJOR`, e.g. `v2`) is force-moved by the release workflow's `advance-major-alias` job after a successful immutable publish.
+- Existing immutable release tags are never force-pushed or rewritten.
 - `v0` tags stay frozen at the last `v0` release.
 - Every immutable release tag has a GitHub release with generated notes.
 
@@ -27,7 +27,7 @@ Run the package validators from this directory before pushing an immutable tag:
 
 ## npm package
 
-The CLI publishes as `@postman-cse/onboarding-aws-spec-discovery` with versions that match the GitHub release tag. The rolling `v1` alias updates the action channel and skips npm publishing.
+The CLI publishes as `@postman-cse/onboarding-aws-spec-discovery` with versions that match the GitHub release tag. The rolling major alias updates the action channel and skips npm publishing.
 
 ## Compatibility
 
@@ -35,7 +35,7 @@ This action emits `spec-path`, `service-name`, and resolution metadata for downs
 
 ## Security fixes
 
-Security fixes ship on the latest `v1.x.y` tag and move onto the rolling `v1` alias. Older immutable tags stay published for reproducibility. See [Security Policy](SECURITY.md).
+Security fixes ship on the latest immutable `vMAJOR.MINOR.PATCH` tag and move onto the rolling major alias. Older immutable tags stay published for reproducibility. See [Security Policy](SECURITY.md).
 
 ## Suite release order
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
   ],
   "scripts": {
     "prepare": "git config core.hooksPath .githooks",
-    "build": "npm run typecheck && rm -rf dist && esbuild src/index.ts --bundle --platform=node --target=node24 --format=cjs --outfile=dist/index.cjs && esbuild src/cli.ts --bundle --platform=node --target=node24 --format=cjs --banner:js='#!/usr/bin/env node' --outfile=dist/cli.cjs && chmod 755 dist/cli.cjs",
-    "verify:dist": "npm run build && git diff --ignore-space-at-eol --text --exit-code -- dist",
+    "bundle": "rm -rf dist && esbuild src/index.ts --bundle --platform=node --target=node24 --format=cjs --outfile=dist/index.cjs && esbuild src/cli.ts --bundle --platform=node --target=node24 --format=cjs --banner:js='#!/usr/bin/env node' --outfile=dist/cli.cjs && chmod 755 dist/cli.cjs",
+    "build": "npm run typecheck && npm run bundle",
+    "verify:dist:assert": "node scripts/verify-dist-artifact.mjs",
+    "verify:dist": "npm run build && git diff --ignore-space-at-eol --text --exit-code -- dist && npm run verify:dist:assert",
     "docs:tables": "node scripts/render-action-tables.mjs",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/scripts/verify-dist-artifact.mjs
+++ b/scripts/verify-dist-artifact.mjs
@@ -1,0 +1,478 @@
+#!/usr/bin/env node
+/**
+ * Read-only dist artifact contract (canonical, fleet-identical).
+ *
+ * This file is byte-identical across every postman-actions onboarding
+ * action repository. All repo-specific facts are derived from manifests:
+ *
+ * - package.json `bin`   -> CLI entrypoint + usage banner name
+ * - package.json `main`  -> library entrypoint
+ * - action.yml runs.main -> GitHub Action entrypoint
+ *
+ * Asserts exact dist census (no hidden/extra files, no symlinks, no missing
+ * entrypoints), CLI shebang, disk + git-index exec bits, sandboxed direct
+ * --help/--version, node --check on every entrypoint, and literal require()
+ * builtins only (bare or node:, via builtinModules).
+ *
+ * The require() scan uses a code-context char-walker that records only
+ * require() calls in CODE position, so it does not false-positive on
+ * bundled codegen template strings (e.g. ajv emits `require("ajv/dist/...")`
+ * INSIDE a backtick template) or on JSDoc examples / string literals.
+ *
+ * Usage: node scripts/verify-dist-artifact.mjs [repoRoot]
+ */
+import { execFileSync, spawnSync } from 'node:child_process';
+import console from 'node:console';
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { builtinModules } from 'node:module';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const defaultRoot = path.resolve(scriptDir, '..');
+const root = path.resolve(process.argv[2] ?? defaultRoot);
+const distDir = path.join(root, 'dist');
+const SHEBANG = '#!/usr/bin/env node\n';
+
+// Optional third-party peers that bundled runtimes (e.g. node-fetch) try to
+// require and swallow on failure. These are NOT runtime dependencies of the
+// action: the bundle runs correctly whether or not they resolve, and the
+// catch swallows any error. Kept narrow, explicit, and documented so any NEW
+// third-party require() in code position still fails the gate.
+const OPTIONAL_PEER_ALLOWLIST = Object.freeze(['encoding']);
+
+function fail(message) {
+  console.error(`verify-dist-artifact: ${message}`);
+  process.exit(1);
+}
+
+function readJson(file) {
+  try {
+    return JSON.parse(readFileSync(file, 'utf8'));
+  } catch (error) {
+    fail(`unable to read ${file}: ${error instanceof Error ? error.message : error}`);
+  }
+  return undefined;
+}
+
+function actionRunsMain(packageRoot) {
+  let text;
+  try {
+    text = readFileSync(path.join(packageRoot, 'action.yml'), 'utf8');
+  } catch {
+    return null;
+  }
+  const lines = text.split('\n');
+  const runsIdx = lines.findIndex((line) => /^runs:\s*$/.test(line));
+  if (runsIdx === -1) {
+    return null;
+  }
+  for (let i = runsIdx + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (/^\S/.test(line)) {
+      break;
+    }
+    const match = line.match(/^\s+main:\s*['"]?([^'"\s]+)['"]?\s*$/);
+    if (match) {
+      return match[1];
+    }
+  }
+  return null;
+}
+
+function deriveManifest() {
+  const pkg = readJson(path.join(root, 'package.json'));
+  const binField =
+    typeof pkg.bin === 'string'
+      ? { [String(pkg.name ?? '').split('/').pop() ?? 'cli']: pkg.bin }
+      : (pkg.bin ?? {});
+  const binNames = Object.keys(binField);
+  if (binNames.length !== 1) {
+    fail(`package.json bin must declare exactly one CLI entry, found ${binNames.length}`);
+  }
+  const binName = binNames[0];
+  const cliRel = binField[binName];
+  if (typeof cliRel !== 'string' || !cliRel.startsWith('dist/')) {
+    fail(`package.json bin.${binName} must point under dist/, found ${JSON.stringify(cliRel)}`);
+  }
+  const census = new Set();
+  if (typeof pkg.main === 'string' && pkg.main.startsWith('dist/')) {
+    census.add(pkg.main.slice('dist/'.length));
+  }
+  census.add(cliRel.slice('dist/'.length));
+  const runsMain = actionRunsMain(root);
+  if (runsMain && runsMain.startsWith('dist/')) {
+    census.add(runsMain.slice('dist/'.length));
+  }
+  if (census.size < 2) {
+    fail(
+      `manifest-derived dist census has ${census.size} entries; expected at least a CLI and one library/action entrypoint`
+    );
+  }
+  return {
+    version: String(pkg.version),
+    binName,
+    cliRel,
+    expectedDist: [...census].sort((left, right) => left.localeCompare(right))
+  };
+}
+
+const manifest = deriveManifest();
+const CLI_REL = manifest.cliRel.split('/').join(path.sep);
+
+function isNodeBuiltin(specifier) {
+  if (specifier.startsWith('.') || path.isAbsolute(specifier)) {
+    return false;
+  }
+  const bare = specifier.startsWith('node:') ? specifier.slice('node:'.length) : specifier;
+  return builtinModules.includes(bare) || builtinModules.includes(specifier);
+}
+
+function isAllowedOptionalPeer(specifier) {
+  return OPTIONAL_PEER_ALLOWLIST.includes(specifier);
+}
+
+// Walk the source tracking string, template, comment, AND regex-literal
+// state. Record a require() call ONLY when `require` appears as an
+// identifier in CODE position. Regex literals are recognized with the
+// standard operand-position heuristic (a `/` after an operator, opening
+// bracket, keyword such as return/typeof/case, or at expression start opens
+// a regex; after an identifier/literal it is division). Without this, dist
+// bundles containing regexes like /["'`]/ desync the walker and produce
+// false positives on codegen template strings (e.g. ajv emits
+// `require("ajv/dist/...")` INSIDE a backtick template).
+function literalRequireSpecifiers(source) {
+  const specifiers = [];
+  const n = source.length;
+  const REGEX_KEYWORDS = new Set([
+    'return', 'typeof', 'instanceof', 'in', 'of', 'new', 'delete', 'void',
+    'throw', 'case', 'do', 'else', 'yield', 'await'
+  ]);
+
+  function skipQuoted(start, quote) {
+    let i = start + 1;
+    while (i < n) {
+      if (source[i] === '\\') { i += 2; continue; }
+      if (source[i] === quote) { return i + 1; }
+      i += 1;
+    }
+    return i;
+  }
+
+  function skipBlockComment(start) {
+    let i = start + 2;
+    while (i < n && !(source[i] === '*' && source[i + 1] === '/')) i += 1;
+    return Math.min(n, i + 2);
+  }
+
+  function skipLineComment(start) {
+    let i = start + 2;
+    while (i < n && source[i] !== '\n') i += 1;
+    return i;
+  }
+
+  function skipRegex(start) {
+    let i = start + 1;
+    let inClass = false;
+    while (i < n) {
+      const c = source[i];
+      if (c === '\\') { i += 2; continue; }
+      if (c === '\n') { return i; }
+      if (inClass) {
+        if (c === ']') { inClass = false; }
+        i += 1;
+        continue;
+      }
+      if (c === '[') { inClass = true; i += 1; continue; }
+      if (c === '/') {
+        i += 1;
+        while (i < n && /[a-z]/i.test(source[i])) i += 1;
+        return i;
+      }
+      i += 1;
+    }
+    return i;
+  }
+
+  // Decide whether a `/` at position i opens a regex literal, given the
+  // index of the last significant (non-space, non-comment) character.
+  function regexPossible(lastSigIdx) {
+    if (lastSigIdx < 0) { return true; }
+    const c = source[lastSigIdx];
+    if (/[A-Za-z0-9_$]/.test(c)) {
+      let k = lastSigIdx;
+      while (k >= 0 && /[A-Za-z0-9_$]/.test(source[k])) k -= 1;
+      const word = source.slice(k + 1, lastSigIdx + 1);
+      return REGEX_KEYWORDS.has(word);
+    }
+    if (c === ')' || c === ']' || c === '}') { return false; }
+    if (c === '"' || c === "'" || c === '`') { return false; }
+    return true;
+  }
+
+  // Scan code starting at `start`. When `stopAtBrace` is true, return at the
+  // matching depth-0 `}` (used for template interpolations). require() calls
+  // found in code position anywhere (including interpolation code) are
+  // recorded.
+  function scanCode(start, stopAtBrace) {
+    let i = start;
+    let depth = 0;
+    let lastSigIdx = -1;
+    while (i < n) {
+      const c = source[i];
+      const next = source[i + 1];
+      if (c === '/' && next === '*') { i = skipBlockComment(i); continue; }
+      if (c === '/' && next === '/') { i = skipLineComment(i); continue; }
+      if (c === '/') {
+        if (regexPossible(lastSigIdx)) { i = skipRegex(i); lastSigIdx = -1; continue; }
+        lastSigIdx = i;
+        i += 1;
+        continue;
+      }
+      if (c === '"' || c === "'") { i = skipQuoted(i, c); lastSigIdx = i - 1; continue; }
+      if (c === '`') { i = scanTemplate(i); lastSigIdx = i - 1; continue; }
+      if (stopAtBrace) {
+        if (c === '{') { depth += 1; lastSigIdx = i; i += 1; continue; }
+        if (c === '}') {
+          if (depth === 0) { return i + 1; }
+          depth -= 1;
+          lastSigIdx = i;
+          i += 1;
+          continue;
+        }
+      }
+      if (c === 'r' && source.slice(i, i + 7) === 'require') {
+        const before = source[i - 1];
+        if ((before && /[A-Za-z0-9_$]/.test(before)) || before === '.') { lastSigIdx = i + 6; i += 7; continue; }
+        let j = i + 7;
+        while (j < n && /\s/.test(source[j])) j += 1;
+        if (source[j] !== '(') { lastSigIdx = i + 6; i += 7; continue; }
+        j += 1;
+        while (j < n && /\s/.test(source[j])) j += 1;
+        const quote = source[j];
+        if (quote !== '"' && quote !== "'") { lastSigIdx = j - 1; i = j; continue; }
+        j += 1;
+        let spec = '';
+        while (j < n && source[j] !== quote) {
+          if (source[j] === '\\') { spec += source[j + 1] ?? ''; j += 2; continue; }
+          spec += source[j];
+          j += 1;
+        }
+        j += 1;
+        while (j < n && /\s/.test(source[j])) j += 1;
+        if (source[j] === ')') { specifiers.push(spec); }
+        lastSigIdx = j;
+        i = j;
+        continue;
+      }
+      if (!/\s/.test(c)) { lastSigIdx = i; }
+      i += 1;
+    }
+    return i;
+  }
+
+  // `start` points at the opening backtick; returns index after the closing
+  // backtick. Interpolations are scanned as code (recursively), so nested
+  // templates, strings, and regexes inside ${...} are handled exactly.
+  function scanTemplate(start) {
+    let i = start + 1;
+    while (i < n) {
+      if (source[i] === '\\') { i += 2; continue; }
+      if (source[i] === '`') { return i + 1; }
+      if (source[i] === '$' && source[i + 1] === '{') {
+        i = scanCode(i + 2, true);
+        continue;
+      }
+      i += 1;
+    }
+    return i;
+  }
+
+  scanCode(0, false);
+  return specifiers;
+}
+
+function assertExactCensus() {
+  let entries;
+  try {
+    entries = readdirSync(distDir, { withFileTypes: true }).sort((left, right) =>
+      left.name.localeCompare(right.name)
+    );
+  } catch (error) {
+    fail(`unable to read ${distDir}: ${error instanceof Error ? error.message : error}`);
+  }
+  const expected = manifest.expectedDist;
+  const names = entries.map((entry) => entry.name);
+  if (names.length !== expected.length || names.some((name, i) => name !== expected[i])) {
+    fail(
+      `dist census mismatch: got [${names.join(', ')}], expected exact [${expected.join(', ')}] (unexpected file or missing entrypoint)`
+    );
+  }
+  const nonFiles = entries.filter((entry) => !entry.isFile()).map((entry) => entry.name);
+  if (nonFiles.length > 0) {
+    fail(`dist entrypoint must be a regular file, not a directory or symlink: ${nonFiles.join(', ')}`);
+  }
+}
+
+function assertShebang() {
+  let contents;
+  try {
+    contents = readFileSync(path.join(root, CLI_REL), 'utf8');
+  } catch (error) {
+    fail(`unable to read ${CLI_REL}: ${error instanceof Error ? error.message : error}`);
+  }
+  if (!contents.startsWith(SHEBANG)) {
+    fail(`${CLI_REL} missing Node shebang (expected first line ${JSON.stringify(SHEBANG.trim())})`);
+  }
+}
+
+function assertDiskExecutable() {
+  const cliPath = path.join(root, CLI_REL);
+  const mode = statSync(cliPath).mode;
+  if ((mode & 0o111) === 0) {
+    fail(`${CLI_REL} is not executable on disk (mode 0o${(mode & 0o777).toString(8)}; need 0o111 bits)`);
+  }
+}
+
+function gitContextOrNull() {
+  try {
+    const toplevel = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      cwd: root,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    }).trim();
+    const prefix = execFileSync('git', ['rev-parse', '--show-prefix'], {
+      cwd: root,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    }).trim();
+    return { toplevel, prefix };
+  } catch {
+    return null;
+  }
+}
+
+function assertGitIndexExec() {
+  const git = gitContextOrNull();
+  if (!git) {
+    // Temp fixture trees used by edge tests are not a git worktree.
+    return;
+  }
+  const cliPathspec = `${git.prefix}${CLI_REL.split(path.sep).join('/')}`;
+  let stage;
+  try {
+    stage = execFileSync('git', ['ls-files', '--stage', '--', cliPathspec], {
+      cwd: git.toplevel,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe']
+    }).trim();
+  } catch (error) {
+    fail(`unable to read git index for ${CLI_REL}: ${error instanceof Error ? error.message : error}`);
+  }
+  if (!stage) {
+    fail(`${CLI_REL} is not tracked in the git index`);
+  }
+  const mode = stage.split(' ', 1)[0];
+  if (mode !== '100755') {
+    fail(`${CLI_REL} git-index mode is ${mode}, expected 100755 (executable)`);
+  }
+}
+
+function assertDirectHelpAndVersion() {
+  const cliPath = path.join(root, CLI_REL);
+  const sandbox = mkdtempSync(path.join(tmpdir(), 'verify-dist-sandbox-'));
+  const homeDir = path.join(sandbox, 'home');
+  const tmpDir = path.join(sandbox, 'tmp');
+  mkdirSync(homeDir, { recursive: true });
+  mkdirSync(tmpDir, { recursive: true });
+  // Minimal environment: no ambient credentials or CI variables leak into
+  // the CLI under test, and #!/usr/bin/env node still resolves.
+  const sandboxedEnv = {
+    PATH: [path.dirname(process.execPath), process.env.PATH ?? ''].filter(Boolean).join(path.delimiter),
+    HOME: homeDir,
+    TMPDIR: tmpDir,
+    TMP: tmpDir,
+    TEMP: tmpDir,
+    XDG_CACHE_HOME: path.join(homeDir, '.cache'),
+    XDG_CONFIG_HOME: path.join(homeDir, '.config'),
+    XDG_DATA_HOME: path.join(homeDir, '.local', 'share'),
+    XDG_STATE_HOME: path.join(homeDir, '.local', 'state')
+  };
+  const usagePattern = new RegExp(
+    `Usage:\\s+${manifest.binName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`,
+    'i'
+  );
+  try {
+    const help = spawnSync(cliPath, ['--help'], {
+      cwd: root,
+      encoding: 'utf8',
+      env: sandboxedEnv
+    });
+    if (help.status !== 0) {
+      fail(`direct ${CLI_REL} --help exited ${help.status}: ${help.stderr || help.stdout}`);
+    }
+    if (!usagePattern.test(help.stdout)) {
+      fail(`direct ${CLI_REL} --help missing usage banner (expected /Usage: ${manifest.binName}/)`);
+    }
+    if (/permission denied|exec format|syntax error|unexpected token|"use strict"/i.test(help.stderr)) {
+      fail(`direct ${CLI_REL} --help produced shell/exec errors`);
+    }
+
+    const version = spawnSync(cliPath, ['--version'], {
+      cwd: root,
+      encoding: 'utf8',
+      env: sandboxedEnv
+    });
+    if (version.status !== 0) {
+      fail(`direct ${CLI_REL} --version exited ${version.status}: ${version.stderr || version.stdout}`);
+    }
+    if (version.stdout.trim() !== manifest.version) {
+      fail(
+        `direct ${CLI_REL} --version was ${JSON.stringify(version.stdout.trim())}, expected ${JSON.stringify(manifest.version)}`
+      );
+    }
+  } finally {
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+}
+
+function assertNodeCheck() {
+  for (const name of manifest.expectedDist) {
+    const target = path.join(distDir, name);
+    const result = spawnSync(process.execPath, ['--check', target], {
+      cwd: root,
+      encoding: 'utf8'
+    });
+    if (result.status !== 0) {
+      fail(`node --check ${path.join('dist', name)} failed: ${result.stderr || result.stdout}`);
+    }
+  }
+}
+
+function assertLiteralRequiresAreBuiltins() {
+  for (const name of manifest.expectedDist) {
+    const contents = readFileSync(path.join(distDir, name), 'utf8');
+    for (const specifier of literalRequireSpecifiers(contents)) {
+      if (isAllowedOptionalPeer(specifier)) {
+        continue;
+      }
+      if (!isNodeBuiltin(specifier)) {
+        fail(
+          `${path.join('dist', name)} has non-builtin/third-party require(${JSON.stringify(specifier)}); only Node builtinModules (bare or node:) are allowed`
+        );
+      }
+    }
+  }
+}
+
+assertExactCensus();
+assertShebang();
+assertDiskExecutable();
+assertGitIndexExec();
+assertDirectHelpAndVersion();
+assertNodeCheck();
+assertLiteralRequiresAreBuiltins();
+
+console.log('verify-dist-artifact: ok');

--- a/tests/cli-packaging.test.ts
+++ b/tests/cli-packaging.test.ts
@@ -1,5 +1,5 @@
 import { execFile, spawnSync } from 'node:child_process';
-import { access, constants, lstat, mkdir, mkdtemp, readFile, rm, stat, symlink } from 'node:fs/promises';
+import { access, constants, lstat, mkdir, mkdtemp, readFile, readdir, rm, stat, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -22,7 +22,7 @@ async function makeTempDir(prefix: string): Promise<string> {
 }
 
 describe('CLI packaging contract', () => {
-  it('commits a Node shebang and executable mode on dist/cli.cjs', async () => {
+  it('commits a Node shebang and git-index executable mode on dist/cli.cjs', async () => {
     const cliPath = path.join(repoRoot, 'dist', 'cli.cjs');
     const contents = await readFile(cliPath, 'utf8');
     expect(contents.startsWith('#!/usr/bin/env node\n')).toBe(true);
@@ -30,6 +30,69 @@ describe('CLI packaging contract', () => {
     const mode = (await stat(cliPath)).mode & 0o777;
     expect(mode & 0o111).not.toBe(0);
     await access(cliPath, constants.X_OK);
+
+    const staged = await execFileAsync('git', ['ls-files', '--stage', 'dist/cli.cjs'], {
+      cwd: repoRoot,
+      encoding: 'utf8'
+    });
+    expect(staged.stdout).toMatch(/^100755 /);
+  });
+
+  it('keeps an exact dist census of cli/index entrypoints', async () => {
+    const distDir = path.join(repoRoot, 'dist');
+    const entries = (
+      await execFileAsync('git', ['ls-files', '--', 'dist'], {
+        cwd: repoRoot,
+        encoding: 'utf8'
+      })
+    ).stdout
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((filePath) => path.basename(filePath))
+      .sort();
+    expect(entries).toEqual(['cli.cjs', 'index.cjs']);
+
+    const onDisk = await (await import('node:fs/promises')).readdir(distDir);
+    expect(onDisk.filter((name) => !name.startsWith('.')).sort()).toEqual(['cli.cjs', 'index.cjs']);
+  });
+
+  it('splits bundle/build and keeps the assert-only dist contract read-only', async () => {
+    const packageJson = JSON.parse(await readFile(path.join(repoRoot, 'package.json'), 'utf8')) as {
+      scripts: Record<string, string>;
+    };
+    expect(packageJson.scripts.bundle).toContain("--banner:js='#!/usr/bin/env node'");
+    expect(packageJson.scripts.bundle).toContain('chmod 755 dist/cli.cjs');
+    expect(packageJson.scripts.build).toBe('npm run typecheck && npm run bundle');
+    expect(packageJson.scripts['verify:dist:assert']).toBe('node scripts/verify-dist-artifact.mjs');
+    expect(packageJson.scripts['verify:dist']).toBe(
+      'npm run build && git diff --ignore-space-at-eol --text --exit-code -- dist && npm run verify:dist:assert'
+    );
+  });
+
+  it('does not rebuild dist from any test', async () => {
+    const testEntries = await readdir(path.join(repoRoot, 'tests'), { recursive: true });
+    const testSources = await Promise.all(
+      testEntries
+        .filter((entry) => entry.endsWith('.test.ts'))
+        .map((entry) => readFile(path.join(repoRoot, 'tests', entry), 'utf8'))
+    );
+    const allTests = testSources.join('\n');
+    const rebuildInvocation = new RegExp(
+      String.raw`(?:execFile|spawn)\w*\([\s\S]{0,200}(?:npm[\s'",]+run[\s'",]+(?:build|bundle)|esbuild)`,
+      'i'
+    );
+    expect(allTests).not.toMatch(rebuildInvocation);
+    // Build the forbidden cleanup token at runtime so this assertion text cannot self-match.
+    const rebuildCleanup = ['rm', '-rf', 'dist'].join(' ');
+    expect(allTests.includes(rebuildCleanup)).toBe(false);
+  });
+
+  it('bundles once before CI fan-out and runs only the read-only dist assertion in-gate', async () => {
+    const workflow = await readFile(path.join(repoRoot, '.github', 'workflows', 'ci.yml'), 'utf8');
+    expect(workflow.match(/npm run bundle/g)).toHaveLength(1);
+    expect(workflow).toContain('run dist       npm run verify:dist:assert');
+    expect(workflow).not.toContain('run dist       npm run verify:dist\n');
+    expect(workflow.indexOf('- run: npm run bundle')).toBeLessThan(workflow.indexOf('- name: Run gates'));
   });
 
   it('packs, installs, and runs .bin --help via symlink invocation', async () => {

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -7,7 +7,9 @@ const releaseWorkflow = readFileSync(join(process.cwd(), '.github/workflows/rele
 
 function namedStep(name: string): string {
   const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const match = releaseWorkflow.match(new RegExp(`      - name: ${escapedName}\\n[\\s\\S]*?(?=\\n      - |\\n?$)`));
+  const match = releaseWorkflow.match(
+    new RegExp(`      - name: ${escapedName}\\n[\\s\\S]*?(?=\\n      - |\\n  [a-zA-Z0-9_-]+:|\\n?$)`)
+  );
   return match?.[0] ?? '';
 }
 
@@ -40,5 +42,15 @@ describe('release workflow publishing contract', () => {
     expect(namedStep('Publish to npm')).toContain("if: steps.release_tag.outputs.npm_publish == 'true' && steps.npm_package.outputs.already_published != 'true'");
     expect(namedStep('Attach npm tarball to release')).not.toMatch(/\n\s+if:/);
     expect(namedStep('Upload tarball')).not.toMatch(/\n\s+if:/);
+  });
+
+  it('advances the rolling major alias after an immutable release publishes', () => {
+    expect(releaseWorkflow).toContain('advance-major-alias:');
+    expect(releaseWorkflow).toContain('needs: release');
+    expect(releaseWorkflow).toContain("if: ${{ needs.release.outputs.npm_publish == 'true' }}");
+    expect(releaseWorkflow).toContain('npm_publish: ${{ steps.release_tag.outputs.npm_publish }}');
+    expect(namedStep('Force-move rolling major alias tag')).toContain('git tag -fa "$MAJOR"');
+    expect(namedStep('Force-move rolling major alias tag')).toContain('git push origin "$MAJOR" --force');
+    expect(namedStep('Force-move rolling major alias tag')).toContain('COMMIT="$(git rev-parse "HEAD^{commit}")"');
   });
 });

--- a/tests/verify-dist-artifact.test.ts
+++ b/tests/verify-dist-artifact.test.ts
@@ -1,0 +1,289 @@
+import { execFile } from 'node:child_process';
+import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+interface RepoConfig {
+  pkgName: string;
+  binName: string;
+  pkgMain: string;
+  actionMain: string | null;
+  census: string[];
+}
+
+const CONFIG: RepoConfig = {"pkgName":"@postman-cse/onboarding-aws-spec-discovery","binName":"postman-aws-spec-discovery","pkgMain":"dist/index.cjs","actionMain":"dist/index.cjs","census":["cli.cjs","index.cjs"]};
+
+const execFileAsync = promisify(execFile);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const verifyScript = path.join(repoRoot, 'scripts', 'verify-dist-artifact.mjs');
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+interface FixtureOptions {
+  shebang?: boolean;
+  mode?: number;
+  helpBody?: string;
+  cliVersion?: string;
+  pkgVersion?: string;
+  extraDistFile?: string;
+  omitEntry?: string;
+  symlinkEntry?: string;
+  brokenEntry?: string;
+  requireSpecifier?: string;
+  requireExampleOnly?: string;
+}
+
+async function writeFixture(root: string, options: FixtureOptions = {}): Promise<void> {
+  const distDir = path.join(root, 'dist');
+  await mkdir(distDir, { recursive: true });
+  const realPkg = JSON.parse(await readFile(path.join(repoRoot, 'package.json'), 'utf8')) as {
+    version: string;
+  };
+  const pkgVersion = options.pkgVersion ?? realPkg.version;
+  const cliVersion = options.cliVersion ?? pkgVersion;
+  await writeFile(
+    path.join(root, 'package.json'),
+    JSON.stringify({
+      name: CONFIG.pkgName,
+      version: pkgVersion,
+      main: CONFIG.pkgMain,
+      bin: { [CONFIG.binName]: 'dist/cli.cjs' }
+    }),
+    'utf8'
+  );
+  if (CONFIG.actionMain) {
+    await writeFile(
+      path.join(root, 'action.yml'),
+      `name: fixture\nruns:\n  using: node24\n  main: ${CONFIG.actionMain}\n`,
+      'utf8'
+    );
+  }
+
+  const shebang = options.shebang === false ? '' : '#!/usr/bin/env node\n';
+  const helpBody = options.helpBody ?? `Usage: ${CONFIG.binName} [options]\n`;
+  const requireLine = options.requireSpecifier
+    ? `let peer;\ntry {\n  peer = require(${JSON.stringify(options.requireSpecifier)});\n} catch {\n  peer = undefined;\n}\nvoid peer;\n`
+    : '';
+  const requireExample = options.requireExampleOnly
+    ? `// Example only: require(${JSON.stringify(options.requireExampleOnly)})\nconst example = ${JSON.stringify(`require(${JSON.stringify(options.requireExampleOnly)})`)};\nvoid example;\n`
+    : '';
+  const cliSource = `${shebang}${requireLine}${requireExample}const args = process.argv.slice(2);
+if (args.includes('--help') || args.includes('-h')) {
+  process.stdout.write(${JSON.stringify(helpBody)});
+  process.exit(0);
+}
+if (args.includes('--version') || args.includes('-V')) {
+  process.stdout.write(${JSON.stringify(`${cliVersion}\n`)});
+  process.exit(0);
+}
+process.stderr.write('unexpected\\n');
+process.exit(1);
+`;
+  const cliPath = path.join(distDir, 'cli.cjs');
+  await writeFile(cliPath, cliSource, { encoding: 'utf8', mode: options.mode ?? 0o755 });
+  if (options.mode !== undefined) {
+    await chmod(cliPath, options.mode);
+  }
+  for (const name of CONFIG.census) {
+    if (name === 'cli.cjs' || name === options.omitEntry) {
+      continue;
+    }
+    if (name === options.symlinkEntry) {
+      await symlink(cliPath, path.join(distDir, name));
+      continue;
+    }
+    const body = name === options.brokenEntry ? 'const = broken;\n' : 'module.exports = {};\n';
+    await writeFile(path.join(distDir, name), body, 'utf8');
+  }
+  if (options.extraDistFile) {
+    await writeFile(path.join(distDir, options.extraDistFile), 'module.exports = {};\n', 'utf8');
+  }
+}
+
+async function runVerify(root: string): Promise<{ code: number; stdout: string; stderr: string }> {
+  try {
+    const result = await execFileAsync(process.execPath, [verifyScript, root], {
+      encoding: 'utf8',
+      env: {
+        PATH: process.env.PATH ?? '',
+        HOME: process.env.HOME ?? '',
+        TMPDIR: process.env.TMPDIR ?? ''
+      },
+      maxBuffer: 1024 * 1024
+    });
+    return { code: 0, stdout: result.stdout, stderr: result.stderr };
+  } catch (error) {
+    const execError = error as { code?: number; stdout?: string; stderr?: string };
+    return {
+      code: typeof execError.code === 'number' ? execError.code : 1,
+      stdout: String(execError.stdout ?? ''),
+      stderr: String(execError.stderr ?? '')
+    };
+  }
+}
+
+describe('verify-dist-artifact canonical contract', () => {
+  it('passes against the committed dist artifact', async () => {
+    const result = await runVerify(repoRoot);
+    expect(result.stderr).toBe('');
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('verify-dist-artifact: ok');
+  }, 30_000);
+
+  it('passes a well-formed temporary dist tree', async () => {
+    const root = await makeTempDir('verify-dist-ok-');
+    await writeFixture(root);
+    const result = await runVerify(root);
+    expect(result.stderr).toBe('');
+    expect(result.code).toBe(0);
+  });
+
+  it('fails when the CLI shebang is missing', async () => {
+    const root = await makeTempDir('verify-dist-shebang-');
+    await writeFixture(root, { shebang: false });
+    const result = await runVerify(root);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toMatch(/missing Node shebang/);
+  });
+
+  it('fails when cli.cjs is not executable on disk', async () => {
+    const root = await makeTempDir('verify-dist-mode-');
+    await writeFixture(root, { mode: 0o644 });
+    const result = await runVerify(root);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toMatch(/not executable on disk/);
+  });
+
+  it('fails when the git index does not mark cli.cjs executable', async () => {
+    const gitRoot = await makeTempDir('verify-dist-gitmode-');
+    const pkgRoot = path.join(gitRoot, 'packages', 'pkg');
+    await mkdir(pkgRoot, { recursive: true });
+    await writeFixture(pkgRoot);
+    await execFileAsync('git', ['init', '--quiet'], { cwd: gitRoot });
+    await execFileAsync('git', ['add', '--', '.'], { cwd: gitRoot });
+    await execFileAsync('git', ['update-index', '--chmod=-x', 'packages/pkg/dist/cli.cjs'], {
+      cwd: gitRoot
+    });
+    const result = await runVerify(pkgRoot);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toMatch(/git-index mode is 100644/);
+  });
+
+  it('fails when dist census has an extra file', async () => {
+    const root = await makeTempDir('verify-dist-extra-');
+    await writeFixture(root, { extraDistFile: 'extra.cjs' });
+    const result = await runVerify(root);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toMatch(/dist census mismatch/);
+  });
+
+  it('fails when dist census has a hidden extra file', async () => {
+    const root = await makeTempDir('verify-dist-hidden-');
+    await writeFixture(root, { extraDistFile: '.hidden' });
+    const result = await runVerify(root);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toMatch(/dist census mismatch/);
+  });
+
+  it('fails when dist census is missing an entrypoint', async () => {
+    const root = await makeTempDir('verify-dist-missing-');
+    const missing = CONFIG.census.find((name) => name !== 'cli.cjs') as string;
+    await writeFixture(root, { omitEntry: missing });
+    const result = await runVerify(root);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toMatch(/dist census mismatch/);
+  });
+
+  it('fails when an expected entrypoint is a symlink', async () => {
+    const root = await makeTempDir('verify-dist-symlink-');
+    const linked = CONFIG.census.find((name) => name !== 'cli.cjs') as string;
+    await writeFixture(root, { symlinkEntry: linked });
+    const result = await runVerify(root);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toMatch(/regular file, not a directory or symlink/);
+  });
+
+  it('fails when direct --help does not produce the usage banner', async () => {
+    const root = await makeTempDir('verify-dist-help-');
+    await writeFixture(root, { helpBody: 'no banner here\n' });
+    const result = await runVerify(root);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toMatch(/missing usage banner/);
+  });
+
+  it('fails when direct --version drifts from package.json', async () => {
+    const root = await makeTempDir('verify-dist-version-');
+    await writeFixture(root, { cliVersion: '0.0.0-drift' });
+    const result = await runVerify(root);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toMatch(/--version was/);
+  });
+
+  it('fails when node --check rejects a bundled entrypoint', async () => {
+    const root = await makeTempDir('verify-dist-syntax-');
+    const broken = CONFIG.census.find((name) => name !== 'cli.cjs') as string;
+    await writeFixture(root, { brokenEntry: broken });
+    const result = await runVerify(root);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toMatch(/node --check/);
+  });
+
+  it('fails when a literal require() targets a third-party module', async () => {
+    const root = await makeTempDir('verify-dist-thirdparty-');
+    await writeFixture(root, { requireSpecifier: 'left-pad' });
+    const result = await runVerify(root);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toMatch(/non-builtin\/third-party require\("left-pad"\)/);
+  });
+
+  it('fails when a literal require() targets a relative path', async () => {
+    const root = await makeTempDir('verify-dist-relative-');
+    await writeFixture(root, { requireSpecifier: './side-effect.cjs' });
+    const result = await runVerify(root);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toMatch(/non-builtin\/third-party require/);
+  });
+
+  it('ignores require() examples in comments and string data', async () => {
+    const root = await makeTempDir('verify-dist-example-');
+    await writeFixture(root, { requireExampleOnly: 'left-pad' });
+    const result = await runVerify(root);
+    expect(result.stderr).toBe('');
+    expect(result.code).toBe(0);
+  });
+
+  it('accepts bare and node: builtin require() specifiers', async () => {
+    const rootBare = await makeTempDir('verify-dist-bare-');
+    await writeFixture(rootBare, { requireSpecifier: 'fs' });
+    const bare = await runVerify(rootBare);
+    expect(bare.stderr).toBe('');
+    expect(bare.code).toBe(0);
+
+    const rootPrefixed = await makeTempDir('verify-dist-prefixed-');
+    await writeFixture(rootPrefixed, { requireSpecifier: 'node:fs' });
+    const prefixed = await runVerify(rootPrefixed);
+    expect(prefixed.stderr).toBe('');
+    expect(prefixed.code).toBe(0);
+  });
+
+  it('accepts the documented optional peer allowlist', async () => {
+    const root = await makeTempDir('verify-dist-peer-');
+    await writeFixture(root, { requireSpecifier: 'encoding' });
+    const result = await runVerify(root);
+    expect(result.stderr).toBe('');
+    expect(result.code).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- manifest-derived read-only dist artifact contract, byte-identical fleet-wide (census, shebang, exec bits, sandboxed --help/--version, node --check, builtin-only require scanner with regex/template-aware walker)
- CI dist gate switched to read-only `verify:dist:assert` (kills the in-gate rebuild race)
- release workflow advances the rolling major alias after publish
- canonical 17-case verify-dist-artifact test suite

## Testing
- npm test / typecheck / lint / verify:dist:assert / actionlint all green locally