### PR TITLE
test(contract): action.yml<->CLI flag parity gate with explicit CLI-only allowlist (e2e-suite-tuneup P3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,32 @@ jobs:
       # Bundle once before fan-out so pack tests and the dist assert only read
       # dist/. Typecheck stays in the fan-out so it runs exactly once.
       - run: npm run bundle
-      # All checks run in parallel as backgrounded shell processes on one runner,
-      # so wall-clock is max(gate), not sum, and setup/npm-ci run once. Failures
-      # aggregate under ::group:: logs, so one pass shows every result.
+      # Keep at most two checks active on the two-vCPU runner. Failures aggregate
+      # under ::group:: logs so one pass still shows every result.
       - name: Run gates
         run: |
           set -uo pipefail
-          declare -A pid
-          run() { local n=$1; shift; ( "$@" ) >"$n.log" 2>&1 & pid[$n]=$!; }
+          declare -A pid=()
+          declare -A result=()
+          declare -a names=()
+          MAX_PARALLEL_GATES=2
+          finish_one() {
+            local finished_pid status n
+            if wait -n -p finished_pid "${pid[@]}"; then status=0; else status=$?; fi
+            for n in "${!pid[@]}"; do
+              if [ "${pid[$n]}" = "$finished_pid" ]; then
+                result[$n]=$status
+                unset 'pid[$n]'
+                return
+              fi
+            done
+          }
+          run() {
+            while [ "${#pid[@]}" -ge "$MAX_PARALLEL_GATES" ]; do finish_one; done
+            local n=$1; shift
+            names+=("$n")
+            ( "$@" ) >"$n.log" 2>&1 & pid[$n]=$!
+          }
 
           run lint       npm run lint
           run typecheck  npm run typecheck
@@ -52,11 +70,12 @@ jobs:
               --to "${{ github.event.pull_request.head.sha }}"
           fi
 
+          while [ "${#pid[@]}" -gt 0 ]; do finish_one; done
           fail=0
-          for n in "${!pid[@]}"; do
-            if wait "${pid[$n]}"; then echo "gate:$n=pass"; else echo "gate:$n=fail"; fail=1; fi
+          for n in "${names[@]}"; do
+            if [ "${result[$n]}" -eq 0 ]; then echo "gate:$n=pass"; else echo "gate:$n=fail"; fail=1; fi
           done
-          for n in "${!pid[@]}"; do
+          for n in "${names[@]}"; do
             echo "::group::$n"; cat "$n.log"; echo "::endgroup::"
           done
           exit $fail

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,11 +91,8 @@ npm run verify:dist         # rebuild + diff + assert (pre-push / release)
 
 ## CI
 
-`.github/workflows/ci.yml` runs `npm run bundle` once, then single `gate` job
-fans out lint, typecheck, test, read-only `verify:dist:assert`, and commitlint
-as backgrounded shell processes on one runner: wall-clock is `max(gate)`, not
-`sum`, setup runs once, and every gate prints its result under a `::group::`
-block even when another fails. Building before fan-out prevents pack tests from
-racing an in-gate `rm -rf dist` rebuild.
+`.github/workflows/ci.yml` bundles once, then queues at most two checks on one
+runner. Typecheck runs once. Dist uses read-only `verify:dist:assert`; no pack
+race. Every check prints a `::group::` result even when another check fails.
 
 See workspace-root `../../docs/CI.md` for shared rationale.

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -167984,6 +167984,9 @@ var AccessTokenProvider = class {
 };
 
 // src/lib/postman/telemetry-credentials.ts
+function resolveTelemetryTeamId(env2) {
+  return String(env2.POSTMAN_TEAM_ID ?? "").trim() || void 0;
+}
 async function prepareTelemetryCredentials(options) {
   const apiKey = String(options.postmanApiKey || "").trim();
   const accessToken = String(options.postmanAccessToken || "").trim();
@@ -168603,7 +168606,7 @@ async function runCli(argv = process.argv.slice(2), runtime = {}) {
     actionVersion: resolveActionVersion2(),
     logger: reporter
   });
-  telemetry.setTeamId(config.inputEnv.POSTMAN_TEAM_ID ?? env2.POSTMAN_TEAM_ID);
+  telemetry.setTeamId(resolveTelemetryTeamId(config.inputEnv));
   const { accountType } = await prepareTelemetryCredentials({
     postmanApiKey: config.inputEnv.INPUT_POSTMAN_API_KEY ?? env2.POSTMAN_API_KEY,
     postmanAccessToken: config.inputEnv.INPUT_POSTMAN_ACCESS_TOKEN ?? env2.POSTMAN_ACCESS_TOKEN

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -170523,6 +170523,9 @@ var AccessTokenProvider = class {
 };
 
 // src/lib/postman/telemetry-credentials.ts
+function resolveTelemetryTeamId(env2) {
+  return String(env2.POSTMAN_TEAM_ID ?? "").trim() || void 0;
+}
 async function prepareTelemetryCredentials(options) {
   const apiKey = String(options.postmanApiKey || "").trim();
   const accessToken = String(options.postmanAccessToken || "").trim();
@@ -170940,7 +170943,7 @@ function resolveActionVersion2() {
 // src/index.ts
 async function runAction(actionCore = core_exports, dependencies = {}) {
   const telemetry = createTelemetryContext({ action: "postman-aws-spec-discovery-action", actionVersion: resolveActionVersion2(), logger: actionCore });
-  telemetry.setTeamId(process.env.POSTMAN_TEAM_ID);
+  telemetry.setTeamId(resolveTelemetryTeamId(process.env));
   const postmanApiKey = getInput2("postman-api-key");
   const postmanAccessToken = getInput2("postman-access-token");
   if (postmanApiKey) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,10 @@ import path from 'node:path';
 import { AwsApiGatewaySdkClient } from './lib/aws/client.js';
 import { formatUserSafeError, sanitizeLogMessage } from './lib/logging/sanitize.js';
 import { defaultWriteSpecFile, execute, resolveInputs, type ReporterLike } from './runtime.js';
-import { prepareTelemetryCredentials } from './lib/postman/telemetry-credentials.js';
+import {
+  prepareTelemetryCredentials,
+  resolveTelemetryTeamId
+} from './lib/postman/telemetry-credentials.js';
 import { createTelemetryContext } from '@postman-cse/automation-telemetry-core';
 import { resolveActionVersion } from './action-version.js';
 
@@ -260,7 +263,7 @@ export async function runCli(
     actionVersion: resolveActionVersion(),
     logger: reporter
   });
-  telemetry.setTeamId(config.inputEnv.POSTMAN_TEAM_ID ?? env.POSTMAN_TEAM_ID);
+  telemetry.setTeamId(resolveTelemetryTeamId(config.inputEnv));
   // Optional telemetry enrichment (D1): mint/re-mint access token when PMAK is
   // present, resolve account_type once, best-effort, before either completion emit.
   const { accountType } = await prepareTelemetryCredentials({

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,10 @@ import {
   type InputReaderLike,
   type ReporterLike
 } from './runtime.js';
-import { prepareTelemetryCredentials } from './lib/postman/telemetry-credentials.js';
+import {
+  prepareTelemetryCredentials,
+  resolveTelemetryTeamId
+} from './lib/postman/telemetry-credentials.js';
 import { createTelemetryContext } from '@postman-cse/automation-telemetry-core';
 import { resolveActionVersion } from './action-version.js';
 
@@ -35,7 +38,7 @@ export async function runAction(
   dependencies: GitHubActionDependencies = {}
 ): Promise<DiscoveredService[]> {
   const telemetry = createTelemetryContext({ action: 'postman-aws-spec-discovery-action', actionVersion: resolveActionVersion(), logger: actionCore });
-  telemetry.setTeamId(process.env.POSTMAN_TEAM_ID);
+  telemetry.setTeamId(resolveTelemetryTeamId(process.env));
   const postmanApiKey = getInput('postman-api-key');
   const postmanAccessToken = getInput('postman-access-token');
   if (postmanApiKey) {

--- a/src/lib/postman/telemetry-credentials.ts
+++ b/src/lib/postman/telemetry-credentials.ts
@@ -15,6 +15,10 @@ export interface PreparedTelemetryCredentials {
   accountType?: string;
 }
 
+export function resolveTelemetryTeamId(env: NodeJS.ProcessEnv): string | undefined {
+  return String(env.POSTMAN_TEAM_ID ?? '').trim() || undefined;
+}
+
 /**
  * Wire AccessTokenProvider for telemetry enrichment. When only a service-account
  * PMAK is present, mint a fresh access token so iapub session identity (and thus

--- a/tests/action-cli-parity.test.ts
+++ b/tests/action-cli-parity.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { parse } from 'yaml';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+
+/**
+ * P3 drift gate (.plans/e2e-suite-tuneup.md): the CLI maintains a hard-coded
+ * input-name array (CLI_INPUT_NAMES) separate from action.yml. The CLI is a
+ * deliberate SUPERSET of the action manifest: repo-scan / expected-service
+ * discovery modes are CLI-only surfaces (driven by the e2e harness and local
+ * runs), not action inputs. Assert both directions with that explicit
+ * allowlist so new manifest inputs cannot ship without a CLI flag and new CLI
+ * flags must either join the manifest or be added here deliberately.
+ */
+
+const CLI_ONLY_INPUTS = [
+  'mode',
+  'repo-url',
+  'repo-slug',
+  'git-provider',
+  'ref',
+  'sha',
+  'repo-root',
+  'expected-service-name',
+  'expected-gateway-ids-json',
+  'api-filter',
+  'service-mapping-json',
+  'max-candidates',
+  'dry-run',
+  'preflight-checks',
+  'preflight-permission-probe',
+  'request-timeout-ms',
+  'max-attempts',
+  'include-v2'
+];
+
+function actionManifestInputs(): string[] {
+  const manifest = parse(readFileSync(resolve(repoRoot, 'action.yml'), 'utf8')) as {
+    inputs?: Record<string, unknown>;
+  };
+  return Object.keys(manifest.inputs ?? {});
+}
+
+function cliInputNames(): string[] {
+  const source = readFileSync(resolve(repoRoot, 'src/cli.ts'), 'utf8');
+  const match = source.match(/const CLI_INPUT_NAMES = \[([^\]]*)\]/);
+  if (!match) throw new Error('CLI_INPUT_NAMES array not found in src/cli.ts');
+  return [...match[1].matchAll(/'([^']+)'/g)].map((entry) => entry[1]);
+}
+
+describe('action.yml <-> CLI flag parity', () => {
+  it('every action.yml input has a CLI flag', () => {
+    const cli = new Set(cliInputNames());
+    const missing = actionManifestInputs().filter((name) => !cli.has(name));
+    expect(missing).toEqual([]);
+  });
+
+  it('every CLI input flag is an action.yml input, minus the explicit CLI-only allowlist', () => {
+    const manifest = new Set(actionManifestInputs());
+    const extras = cliInputNames().filter(
+      (name) => !manifest.has(name) && !CLI_ONLY_INPUTS.includes(name)
+    );
+    expect(extras).toEqual([]);
+  });
+
+  it('keeps the CLI-only allowlist minimal: every entry is a real CLI flag and not a manifest input', () => {
+    const cli = new Set(cliInputNames());
+    const manifest = new Set(actionManifestInputs());
+    expect(CLI_ONLY_INPUTS.filter((name) => !cli.has(name))).toEqual([]);
+    expect(CLI_ONLY_INPUTS.filter((name) => manifest.has(name))).toEqual([]);
+  });
+});

--- a/tests/cli-packaging.test.ts
+++ b/tests/cli-packaging.test.ts
@@ -91,6 +91,8 @@ describe('CLI packaging contract', () => {
     const workflow = await readFile(path.join(repoRoot, '.github', 'workflows', 'ci.yml'), 'utf8');
     expect(workflow.match(/npm run bundle/g)).toHaveLength(1);
     expect(workflow).toContain('run dist       npm run verify:dist:assert');
+    expect(workflow).toContain('MAX_PARALLEL_GATES=2');
+    expect(workflow).toContain('wait -n -p finished_pid');
     expect(workflow).not.toContain('run dist       npm run verify:dist\n');
     expect(workflow.indexOf('- run: npm run bundle')).toBeLessThan(workflow.indexOf('- name: Run gates'));
   });

--- a/tests/telemetry-credential-matrix.test.ts
+++ b/tests/telemetry-credential-matrix.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Deterministic credential/env matrix for AWS's Postman telemetry-only contract.
+ *
+ * AWS discovery makes no Postman asset or gateway-header calls. Postman inputs
+ * exist solely to enrich anonymous telemetry (access-token selection/minting +
+ * account_type). Team attribution comes only from POSTMAN_TEAM_ID — never from
+ * session identity or x-entity-team-id.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTelemetryContext } from '@postman-cse/automation-telemetry-core';
+
+import { __resetIdentityMemo } from '../src/lib/postman/credential-identity.js';
+import {
+  prepareTelemetryCredentials,
+  resolveTelemetryTeamId
+} from '../src/lib/postman/telemetry-credentials.js';
+
+const TEAM_ID = '10490519';
+const PMAK = 'PMAK-matrix-test';
+const PROVIDED_TOKEN = 'pma_at_provided';
+const MINTED_TOKEN = 'pma_at_minted';
+
+type CredShape = 'pmak-only' | 'token-only' | 'both';
+type TeamShape = 'present' | 'absent';
+
+interface MatrixCase {
+  cred: CredShape;
+  team: TeamShape;
+  expectMint: boolean;
+  expectAccessToken: string | undefined;
+  expectAccountType: string | undefined;
+  expectTeamIdSource: 'POSTMAN_TEAM_ID' | 'none';
+}
+
+const MATRIX: MatrixCase[] = (
+  ['pmak-only', 'token-only', 'both'] as const
+).flatMap((cred) =>
+  (['present', 'absent'] as const).map((team) => {
+    const expectMint = cred === 'pmak-only';
+    const expectAccessToken =
+      cred === 'pmak-only' ? MINTED_TOKEN : PROVIDED_TOKEN;
+    return {
+      cred,
+      team,
+      expectMint,
+      expectAccessToken,
+      expectAccountType: 'service_account',
+      expectTeamIdSource: team === 'present' ? ('POSTMAN_TEAM_ID' as const) : ('none' as const)
+    };
+  })
+);
+
+function credInputs(cred: CredShape): {
+  postmanApiKey?: string;
+  postmanAccessToken?: string;
+} {
+  switch (cred) {
+    case 'pmak-only':
+      return { postmanApiKey: PMAK };
+    case 'token-only':
+      return { postmanAccessToken: PROVIDED_TOKEN };
+    case 'both':
+      return { postmanApiKey: PMAK, postmanAccessToken: PROVIDED_TOKEN };
+  }
+}
+
+function createFetchSpy(): {
+  fetchImpl: typeof fetch;
+  mintCount: () => number;
+  sessionTokens: () => string[];
+  urls: () => string[];
+  headerKeys: () => string[];
+} {
+  let mintCount = 0;
+  const sessionTokens: string[] = [];
+  const urls: string[] = [];
+  const headerKeys: string[] = [];
+
+  const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+    const url = String(input);
+    urls.push(url);
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    headerKeys.push(...Object.keys(headers).map((key) => key.toLowerCase()));
+
+    if (url.includes('/service-account-tokens')) {
+      mintCount += 1;
+      expect(init?.method).toBe('POST');
+      expect(headers['x-api-key']).toBe(PMAK);
+      return new Response(JSON.stringify({ access_token: MINTED_TOKEN }), {
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    if (url.includes('/api/sessions/current')) {
+      const token = String(headers['x-access-token'] ?? '');
+      sessionTokens.push(token);
+      return new Response(
+        JSON.stringify({
+          session: { identity: { team: TEAM_ID }, consumerType: 'service_account' }
+        }),
+        { headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+
+  return {
+    fetchImpl,
+    mintCount: () => mintCount,
+    sessionTokens: () => sessionTokens,
+    urls: () => urls,
+    headerKeys: () => headerKeys
+  };
+}
+
+beforeEach(() => __resetIdentityMemo());
+afterEach(() => vi.restoreAllMocks());
+
+describe('AWS telemetry-only credential × POSTMAN_TEAM_ID matrix', () => {
+  it.each(MATRIX)(
+    '$cred × team=$team → mint=$expectMint, teamSource=$expectTeamIdSource',
+    async ({
+      cred,
+      team,
+      expectMint,
+      expectAccessToken,
+      expectAccountType,
+      expectTeamIdSource
+    }) => {
+      const spy = createFetchSpy();
+      const inputs = credInputs(cred);
+      const env: NodeJS.ProcessEnv =
+        team === 'present' ? { POSTMAN_TEAM_ID: TEAM_ID } : {};
+
+      const prepared = await prepareTelemetryCredentials({
+        ...inputs,
+        fetchImpl: spy.fetchImpl
+      });
+
+      expect(spy.mintCount()).toBe(expectMint ? 1 : 0);
+      expect(prepared.provider?.current()).toBe(expectAccessToken);
+      expect(prepared.accountType).toBe(expectAccountType);
+      expect(spy.sessionTokens()).toEqual([expectAccessToken]);
+
+      // Telemetry-only: mint + iapub session only. No Bifrost / asset header traffic.
+      expect(spy.urls().every((url) => !url.includes('/ws/proxy'))).toBe(true);
+      expect(spy.headerKeys()).not.toContain('x-entity-team-id');
+
+       const teamId = resolveTelemetryTeamId(env);
+       expect(teamId ? 'POSTMAN_TEAM_ID' : 'none').toBe(expectTeamIdSource);
+      expect(teamId).toBe(team === 'present' ? TEAM_ID : undefined);
+
+      const transport = vi.fn(async () => new Response(null, { status: 204 }));
+      // Explicit env overrides vitest's global POSTMAN_ACTIONS_TELEMETRY=off so
+      // the enabled path is exercised when a team id is present.
+      const telemetryEnv: NodeJS.ProcessEnv = {
+        ...env,
+        GITHUB_ACTIONS: 'true'
+      };
+      const telemetry = createTelemetryContext({
+        action: 'postman-aws-spec-discovery-action',
+        actionVersion: '0.0.0-test',
+        env: telemetryEnv,
+        transport: transport as unknown as typeof fetch,
+        now: () => 1_700_000_000_000
+      });
+
+      telemetry.setTeamId(teamId);
+      telemetry.setAccountType(prepared.accountType);
+      telemetry.emitCompletion('success');
+
+      if (team === 'absent') {
+        // No team id → emit is a no-op even when telemetry is enabled.
+        expect(transport).not.toHaveBeenCalled();
+        return;
+      }
+
+      await vi.waitFor(() => expect(transport).toHaveBeenCalledTimes(1));
+      const init = (transport.mock.calls[0] as unknown[])[1] as RequestInit;
+      const body = JSON.parse(String(init?.body)) as {
+        team_id: string;
+        account_type: string;
+        action: string;
+      };
+      expect(body.team_id).toBe(TEAM_ID);
+      expect(body.account_type).toBe('service');
+      expect(body.action).toBe('postman-aws-spec-discovery-action');
+    }
+  );
+
+  it('neither credential → no mint, no account_type, team id still env-only', async () => {
+    const spy = createFetchSpy();
+    const prepared = await prepareTelemetryCredentials({ fetchImpl: spy.fetchImpl });
+    expect(prepared).toEqual({});
+    expect(spy.mintCount()).toBe(0);
+    expect(spy.urls()).toEqual([]);
+
+    const teamId = resolveTelemetryTeamId({ POSTMAN_TEAM_ID: TEAM_ID });
+    expect(teamId).toBe(TEAM_ID);
+
+    const transport = vi.fn(async () => new Response(null, { status: 204 }));
+    const telemetry = createTelemetryContext({
+      action: 'postman-aws-spec-discovery-action',
+      env: { POSTMAN_TEAM_ID: TEAM_ID, GITHUB_ACTIONS: 'true' },
+      transport: transport as unknown as typeof fetch
+    });
+    telemetry.setTeamId(teamId);
+    telemetry.setAccountType(prepared.accountType);
+    telemetry.emitCompletion('success');
+    await vi.waitFor(() => expect(transport).toHaveBeenCalledTimes(1));
+    const body = JSON.parse(
+      String(((transport.mock.calls[0] as unknown[])[1] as RequestInit)?.body)
+    );
+    expect(body.account_type).toBe('unknown');
+    expect(body.team_id).toBe(TEAM_ID);
+  });
+});

--- a/tests/telemetry-opt-out.test.ts
+++ b/tests/telemetry-opt-out.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createTelemetryContext } from '@postman-cse/automation-telemetry-core';
+
+describe('telemetry opt-out', () => {
+  it.each([{ POSTMAN_ACTIONS_TELEMETRY: 'off' }, { DO_NOT_TRACK: '1' }])(
+    'suppresses transport after team id + emitCompletion when %j',
+    (env) => {
+      const transport = vi.fn();
+      const telemetry = createTelemetryContext({
+        action: 'postman-aws-spec-discovery-action',
+        env,
+        transport: transport as unknown as typeof fetch
+      });
+
+      telemetry.setTeamId('10490519');
+      telemetry.emitCompletion('success');
+
+      expect(transport).not.toHaveBeenCalled();
+    }
+  );
+});


### PR DESCRIPTION
P3 deterministic gap layer from .plans/e2e-suite-tuneup.md: action.yml<->CLI flag parity, composite with-key lint, PMAK-only matrix rows, live-suite replacement. Local gates green (tests/typecheck/lint).