### PR TITLE
feat(discovery): audit API Gateway schema coverage

### DIFF
--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -161508,6 +161508,95 @@ function resolveServiceCandidate(gateways, signals) {
 // src/lib/spec/normalize-openapi.ts
 var import_yaml4 = __toESM(require_dist(), 1);
 var HTTP_METHODS = /* @__PURE__ */ new Set(["get", "put", "post", "delete", "options", "head", "patch", "trace"]);
+function asRecord(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : void 0;
+}
+function resolveLocalObject(root5, value) {
+  let current = asRecord(value);
+  const seen = /* @__PURE__ */ new Set();
+  while (current && typeof current.$ref === "string") {
+    if (seen.has(current) || !current.$ref.startsWith("#/")) return void 0;
+    seen.add(current);
+    let resolved = root5;
+    for (const rawSegment of current.$ref.slice(2).split("/")) {
+      const segment = rawSegment.replace(/~1/g, "/").replace(/~0/g, "~");
+      resolved = asRecord(resolved)?.[segment];
+    }
+    current = asRecord(resolved);
+  }
+  return current;
+}
+function responseIsStaticallyBodyless(method, status) {
+  const normalized = status.toUpperCase();
+  return method === "head" || normalized === "1XX" || /^1[0-9][0-9]$/.test(normalized) || normalized === "204" || normalized === "205" || normalized === "304";
+}
+function isResponseDeclarationKey(value) {
+  return value.toLowerCase() === "default" || /^[1-5](?:[0-9]{2}|xx)$/i.test(value);
+}
+function auditOpenApiContractCoverage(value) {
+  const root5 = asRecord(value);
+  const paths = asRecord(root5?.paths);
+  if (!root5 || typeof root5.openapi !== "string" || !/^3\./.test(root5.openapi) || !paths) return void 0;
+  const audit = {
+    schemaVersion: 1,
+    status: "schema-complete",
+    operationCount: 0,
+    responseCount: 0,
+    responsesWithoutContent: 0,
+    responseMediaTypesWithoutSchema: 0,
+    requestMediaTypesWithoutSchema: 0,
+    defaultOnlyOperationCount: 0
+  };
+  for (const rawPathItem of Object.values(paths)) {
+    const pathItem = resolveLocalObject(root5, rawPathItem);
+    if (!pathItem) return void 0;
+    for (const [rawMethod, rawOperation] of Object.entries(pathItem)) {
+      const method = rawMethod.toLowerCase();
+      if (!HTTP_METHODS.has(method)) continue;
+      const operation2 = resolveLocalObject(root5, rawOperation);
+      if (!operation2) return void 0;
+      audit.operationCount += 1;
+      const requestBody = operation2.requestBody === void 0 ? void 0 : resolveLocalObject(root5, operation2.requestBody);
+      if (operation2.requestBody !== void 0 && !requestBody) return void 0;
+      const requestContent = asRecord(requestBody?.content);
+      for (const rawMedia of Object.values(requestContent ?? {})) {
+        const media = asRecord(rawMedia);
+        if (!media) return void 0;
+        if (media.schema === void 0) audit.requestMediaTypesWithoutSchema += 1;
+      }
+      const responses = asRecord(operation2.responses);
+      if (!responses) return void 0;
+      const responseKeys = Object.keys(responses).filter(isResponseDeclarationKey);
+      if (responseKeys.length === 0) return void 0;
+      if (responseKeys.some((status) => status.toLowerCase() === "default") && responseKeys.length === 1) {
+        audit.defaultOnlyOperationCount += 1;
+      }
+      for (const status of responseKeys) {
+        const rawResponse = responses[status];
+        audit.responseCount += 1;
+        const response = resolveLocalObject(root5, rawResponse);
+        if (!response) return void 0;
+        const content = asRecord(response?.content);
+        if ((!content || Object.keys(content).length === 0) && !responseIsStaticallyBodyless(method, status)) {
+          audit.responsesWithoutContent += 1;
+        }
+        for (const rawMedia of Object.values(content ?? {})) {
+          const media = asRecord(rawMedia);
+          if (!media) return void 0;
+          if (media.schema === void 0) audit.responseMediaTypesWithoutSchema += 1;
+        }
+      }
+    }
+  }
+  if (audit.responsesWithoutContent > 0 || audit.responseMediaTypesWithoutSchema > 0 || audit.requestMediaTypesWithoutSchema > 0) {
+    audit.status = "schema-incomplete";
+  }
+  return audit;
+}
+function formatOpenApiContractAuditWarning(audit) {
+  if (audit.status !== "schema-incomplete") return void 0;
+  return `AWS_OPENAPI_CONTRACT_INCOMPLETE: API Gateway export has ${audit.responsesWithoutContent} response declaration(s) without content, ${audit.responseMediaTypesWithoutSchema} response media declaration(s) without schema, and ${audit.requestMediaTypesWithoutSchema} request media declaration(s) without schema. Bootstrap keeps route and status checks but skips undocumented body assertions; define API Gateway models or enrich the OpenAPI before treating body-schema tests as strict CI gates.`;
+}
 function normalizeOpenApiYaml(content) {
   const passthrough = { content, renamed: [], normalized: false };
   let doc;
@@ -161555,10 +161644,11 @@ function normalizeOpenApiYaml(content) {
       }
     }
   }
+  const openapiContractAudit = auditOpenApiContractCoverage(doc.toJS());
   if (renamed.length === 0) {
-    return { content, renamed: [], normalized: true };
+    return { content, renamed: [], normalized: true, openapiContractAudit };
   }
-  return { content: String(doc), renamed, normalized: true };
+  return { content: String(doc), renamed, normalized: true, openapiContractAudit };
 }
 function scalarString(node) {
   if ((0, import_yaml4.isScalar)(node) && typeof node.value === "string") return node.value;
@@ -162605,12 +162695,15 @@ var ApiGatewayProvider = class {
         }
       }
     }
+    const contractWarning = normalized.openapiContractAudit ? formatOpenApiContractAuditWarning(normalized.openapiContractAudit) : void 0;
+    if (contractWarning) evidence.push(contractWarning);
     return {
       content: normalized.content,
       format: "openapi-yaml",
       filename: "index.yaml",
       stage,
       derivedOpenApiCompleteness: exported.fallback || gatewayType === "WEBSOCKET" ? "partial" : void 0,
+      openapiContractAudit: normalized.openapiContractAudit,
       evidence
     };
   }
@@ -162647,7 +162740,11 @@ function isKnownRestExportLimitation(message) {
 function safeNormalizeOpenApi(content) {
   try {
     const result = normalizeOpenApiYaml(content);
-    return { content: result.content, renamed: result.renamed };
+    return {
+      content: result.content,
+      renamed: result.renamed,
+      openapiContractAudit: result.openapiContractAudit
+    };
   } catch {
     return { content, renamed: [] };
   }
@@ -166585,14 +166682,21 @@ function normalizeApiGatewaySpec(body, candidate, reporter) {
     reporter.warning(
       userSafeWarning(`Skipped operationId normalization for ${candidate.id}: ${formatUserSafeError(error2)}`)
     );
-    return body;
+    return { content: body };
   }
-  if (!result.normalized || result.renamed.length === 0) return body;
-  for (const rename of result.renamed) {
-    const from = rename.original === null ? "<missing>" : rename.original;
-    reporter.info(`operationId normalized: ${candidate.id} ${rename.method.toUpperCase()} ${rename.path} \`${from}\` -> \`${rename.renamed}\``);
+  if (result.normalized) {
+    for (const rename of result.renamed) {
+      const from = rename.original === null ? "<missing>" : rename.original;
+      reporter.info(`operationId normalized: ${candidate.id} ${rename.method.toUpperCase()} ${rename.path} \`${from}\` -> \`${rename.renamed}\``);
+    }
   }
-  return result.content;
+  const contractWarning = result.openapiContractAudit ? formatOpenApiContractAuditWarning(result.openapiContractAudit) : void 0;
+  if (contractWarning) reporter.warning(userSafeWarning(contractWarning));
+  return {
+    content: result.normalized ? result.content : body,
+    openapiContractAudit: result.openapiContractAudit,
+    contractWarning
+  };
 }
 async function exportApiGatewaySpecBody(aws, candidate, stage) {
   try {
@@ -166950,6 +167054,7 @@ async function exportProviderResolutionCandidate(resolved, inputs, writeSpecFile
     specFormat: result.format,
     metadataPath: relativeMetadataPath,
     stage: result.stage,
+    openapiContractAudit: inputs.dryRun ? void 0 : result.openapiContractAudit,
     ...derivedOpenApi,
     evidence: [...resolved.evidence, ...result.evidence, ...inputs.dryRun ? ["Dry run enabled; skipped provider spec file write"] : []]
   };
@@ -167117,7 +167222,8 @@ async function runDiscovery(inputs, dependencies) {
         }
         const exportedStage = stage ?? "";
         const exported = await exportApiGatewaySpecBody(dependencies.aws, candidate, exportedStage);
-        const specBody = normalizeApiGatewaySpec(exported.content, candidate, dependencies.core);
+        const normalized = normalizeApiGatewaySpec(exported.content, candidate, dependencies.core);
+        const specBody = normalized.content;
         const derivedOpenApi = await writeResolvedArtifactWithDerivedOpenApi({
           repoRoot: resolvedRoot,
           relativeDir: import_node_path14.default.dirname(relativeSpecPath).replace(/\\/g, "/"),
@@ -167140,6 +167246,7 @@ async function runDiscovery(inputs, dependencies) {
           stage: exportedStage,
           providerType: "api-gateway",
           specFormat: "openapi-yaml",
+          openapiContractAudit: normalized.openapiContractAudit,
           ...derivedOpenApi
         });
         for (const evidence of exported.evidence) {
@@ -167432,11 +167539,12 @@ async function runResolution(inputs, awsClient, actionCore, writeSpecFile, resol
         { id: selectedSource.gatewayId, gatewayType: selectedSource.gatewayType },
         selectedSource.gatewayType === "REST" ? selectedSource.stage : stageSelection.useLatestConfig ? void 0 : selectedSource.stage
       );
-      const body = normalizeApiGatewaySpec(
+      const normalized = normalizeApiGatewaySpec(
         exported.content,
         { id: selectedSource.gatewayId, gatewayType: selectedSource.gatewayType, name: selectedSource.serviceName },
         actionCore
       );
+      const body = normalized.content;
       const derivedOpenApi = await writeResolvedArtifactWithDerivedOpenApi({
         repoRoot: inputs.repoRoot,
         relativeDir: import_node_path14.default.dirname(relativeSpecPath).replace(/\\/g, "/"),
@@ -167453,6 +167561,7 @@ async function runResolution(inputs, awsClient, actionCore, writeSpecFile, resol
       selectedSource.specPath = relativeSpecPath;
       selectedSource.providerType = "api-gateway";
       selectedSource.specFormat = "openapi-yaml";
+      selectedSource.openapiContractAudit = normalized.openapiContractAudit;
       Object.assign(selectedSource, derivedOpenApi);
       if (selectedSource.gatewayType === "WEBSOCKET") {
         selectedSource.evidence = [
@@ -167462,6 +167571,9 @@ async function runResolution(inputs, awsClient, actionCore, writeSpecFile, resol
       }
       if (exported.evidence.length > 0) {
         selectedSource.evidence = [...selectedSource.evidence, ...exported.evidence];
+      }
+      if (normalized.contractWarning) {
+        selectedSource.evidence = [...selectedSource.evidence, normalized.contractWarning];
       }
     } catch (error2) {
       const parsed = parseAwsError(error2);
@@ -167629,6 +167741,8 @@ async function runMultiProviderDiscovery(providers, inputs, dependencies, snsRes
             } catch {
             }
           }
+          const contractWarning = result.openapiContractAudit ? formatOpenApiContractAuditWarning(result.openapiContractAudit) : void 0;
+          if (contractWarning) dependencies.core.warning(userSafeWarning(contractWarning));
           discovered.push({
             serviceName,
             specPath: relativeSpecPath,
@@ -167640,6 +167754,7 @@ async function runMultiProviderDiscovery(providers, inputs, dependencies, snsRes
             contractOrigin,
             variantCount,
             metadataPath: metadataSidecar ? import_node_path14.default.join(inputs.outputDir, folderName, metadataSidecar.filename).replace(/\\/g, "/") : void 0,
+            openapiContractAudit: result.openapiContractAudit,
             ...derivedOpenApi
           });
           dependencies.core.info(`Exported ${provider.type} candidate ${candidate.id} (${candidate.name}) to ${relativeSpecPath}`);
@@ -167832,7 +167947,7 @@ function computeSessionRetryDelayMs(response, attempt, random) {
   const ceiling = Math.min(SESSION_RETRY_MAX_DELAY_MS, SESSION_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1));
   return Math.round(random() * ceiling);
 }
-function asRecord(value) {
+function asRecord2(value) {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return void 0;
   }
@@ -167887,17 +168002,17 @@ async function resolveTelemetryAccountType(accessToken, fetchImpl) {
 async function parseSessionResponse(response) {
   let payload2;
   try {
-    payload2 = asRecord(await response.json());
+    payload2 = asRecord2(await response.json());
   } catch {
     return void 0;
   }
   if (!payload2) {
     return void 0;
   }
-  const root5 = asRecord(payload2.session) ?? payload2;
-  const identity = asRecord(root5.identity);
-  const data2 = asRecord(root5.data);
-  const user = asRecord(data2?.user);
+  const root5 = asRecord2(payload2.session) ?? payload2;
+  const identity = asRecord2(root5.identity);
+  const data2 = asRecord2(root5.data);
+  const user = asRecord2(data2?.user);
   const roleEntries = Array.isArray(user?.roles) ? user.roles.map((entry) => coerceText(entry) ?? coerceId(entry)).filter((entry) => Boolean(entry)) : [];
   const singleRole = coerceText(user?.role);
   const roles = roleEntries.length > 0 ? roleEntries : singleRole ? [singleRole] : void 0;

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -158856,6 +158856,7 @@ __export(index_exports, {
   LambdaUrlProvider: () => LambdaUrlProvider,
   StepFunctionsProvider: () => StepFunctionsProvider,
   VerifiedPermissionsProvider: () => VerifiedPermissionsProvider,
+  auditOpenApiContractCoverage: () => auditOpenApiContractCoverage,
   buildExecutionOutputs: () => buildExecutionOutputs,
   buildProviderRegistry: () => buildProviderRegistry,
   collectRepoSignals: () => collectRepoSignals,
@@ -158863,6 +158864,7 @@ __export(index_exports, {
   deriveOpenApiDocument: () => deriveOpenApiDocument,
   detectCatalogApis: () => detectCatalogApis,
   execute: () => execute,
+  formatOpenApiContractAuditWarning: () => formatOpenApiContractAuditWarning,
   getInput: () => getInput2,
   normalizeOpenApiYaml: () => normalizeOpenApiYaml,
   outputNames: () => outputNames,
@@ -162130,6 +162132,95 @@ var ProviderRegistry = class {
 // src/lib/spec/normalize-openapi.ts
 var import_yaml3 = __toESM(require_dist(), 1);
 var HTTP_METHODS = /* @__PURE__ */ new Set(["get", "put", "post", "delete", "options", "head", "patch", "trace"]);
+function asRecord(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : void 0;
+}
+function resolveLocalObject(root5, value) {
+  let current = asRecord(value);
+  const seen = /* @__PURE__ */ new Set();
+  while (current && typeof current.$ref === "string") {
+    if (seen.has(current) || !current.$ref.startsWith("#/")) return void 0;
+    seen.add(current);
+    let resolved = root5;
+    for (const rawSegment of current.$ref.slice(2).split("/")) {
+      const segment = rawSegment.replace(/~1/g, "/").replace(/~0/g, "~");
+      resolved = asRecord(resolved)?.[segment];
+    }
+    current = asRecord(resolved);
+  }
+  return current;
+}
+function responseIsStaticallyBodyless(method, status) {
+  const normalized = status.toUpperCase();
+  return method === "head" || normalized === "1XX" || /^1[0-9][0-9]$/.test(normalized) || normalized === "204" || normalized === "205" || normalized === "304";
+}
+function isResponseDeclarationKey(value) {
+  return value.toLowerCase() === "default" || /^[1-5](?:[0-9]{2}|xx)$/i.test(value);
+}
+function auditOpenApiContractCoverage(value) {
+  const root5 = asRecord(value);
+  const paths = asRecord(root5?.paths);
+  if (!root5 || typeof root5.openapi !== "string" || !/^3\./.test(root5.openapi) || !paths) return void 0;
+  const audit = {
+    schemaVersion: 1,
+    status: "schema-complete",
+    operationCount: 0,
+    responseCount: 0,
+    responsesWithoutContent: 0,
+    responseMediaTypesWithoutSchema: 0,
+    requestMediaTypesWithoutSchema: 0,
+    defaultOnlyOperationCount: 0
+  };
+  for (const rawPathItem of Object.values(paths)) {
+    const pathItem = resolveLocalObject(root5, rawPathItem);
+    if (!pathItem) return void 0;
+    for (const [rawMethod, rawOperation] of Object.entries(pathItem)) {
+      const method = rawMethod.toLowerCase();
+      if (!HTTP_METHODS.has(method)) continue;
+      const operation2 = resolveLocalObject(root5, rawOperation);
+      if (!operation2) return void 0;
+      audit.operationCount += 1;
+      const requestBody = operation2.requestBody === void 0 ? void 0 : resolveLocalObject(root5, operation2.requestBody);
+      if (operation2.requestBody !== void 0 && !requestBody) return void 0;
+      const requestContent = asRecord(requestBody?.content);
+      for (const rawMedia of Object.values(requestContent ?? {})) {
+        const media = asRecord(rawMedia);
+        if (!media) return void 0;
+        if (media.schema === void 0) audit.requestMediaTypesWithoutSchema += 1;
+      }
+      const responses = asRecord(operation2.responses);
+      if (!responses) return void 0;
+      const responseKeys = Object.keys(responses).filter(isResponseDeclarationKey);
+      if (responseKeys.length === 0) return void 0;
+      if (responseKeys.some((status) => status.toLowerCase() === "default") && responseKeys.length === 1) {
+        audit.defaultOnlyOperationCount += 1;
+      }
+      for (const status of responseKeys) {
+        const rawResponse = responses[status];
+        audit.responseCount += 1;
+        const response = resolveLocalObject(root5, rawResponse);
+        if (!response) return void 0;
+        const content = asRecord(response?.content);
+        if ((!content || Object.keys(content).length === 0) && !responseIsStaticallyBodyless(method, status)) {
+          audit.responsesWithoutContent += 1;
+        }
+        for (const rawMedia of Object.values(content ?? {})) {
+          const media = asRecord(rawMedia);
+          if (!media) return void 0;
+          if (media.schema === void 0) audit.responseMediaTypesWithoutSchema += 1;
+        }
+      }
+    }
+  }
+  if (audit.responsesWithoutContent > 0 || audit.responseMediaTypesWithoutSchema > 0 || audit.requestMediaTypesWithoutSchema > 0) {
+    audit.status = "schema-incomplete";
+  }
+  return audit;
+}
+function formatOpenApiContractAuditWarning(audit) {
+  if (audit.status !== "schema-incomplete") return void 0;
+  return `AWS_OPENAPI_CONTRACT_INCOMPLETE: API Gateway export has ${audit.responsesWithoutContent} response declaration(s) without content, ${audit.responseMediaTypesWithoutSchema} response media declaration(s) without schema, and ${audit.requestMediaTypesWithoutSchema} request media declaration(s) without schema. Bootstrap keeps route and status checks but skips undocumented body assertions; define API Gateway models or enrich the OpenAPI before treating body-schema tests as strict CI gates.`;
+}
 function normalizeOpenApiYaml(content) {
   const passthrough = { content, renamed: [], normalized: false };
   let doc;
@@ -162177,10 +162268,11 @@ function normalizeOpenApiYaml(content) {
       }
     }
   }
+  const openapiContractAudit = auditOpenApiContractCoverage(doc.toJS());
   if (renamed.length === 0) {
-    return { content, renamed: [], normalized: true };
+    return { content, renamed: [], normalized: true, openapiContractAudit };
   }
-  return { content: String(doc), renamed, normalized: true };
+  return { content: String(doc), renamed, normalized: true, openapiContractAudit };
 }
 function scalarString(node) {
   if ((0, import_yaml3.isScalar)(node) && typeof node.value === "string") return node.value;
@@ -162296,12 +162388,15 @@ var ApiGatewayProvider = class {
         }
       }
     }
+    const contractWarning = normalized.openapiContractAudit ? formatOpenApiContractAuditWarning(normalized.openapiContractAudit) : void 0;
+    if (contractWarning) evidence.push(contractWarning);
     return {
       content: normalized.content,
       format: "openapi-yaml",
       filename: "index.yaml",
       stage,
       derivedOpenApiCompleteness: exported.fallback || gatewayType === "WEBSOCKET" ? "partial" : void 0,
+      openapiContractAudit: normalized.openapiContractAudit,
       evidence
     };
   }
@@ -162338,7 +162433,11 @@ function isKnownRestExportLimitation(message) {
 function safeNormalizeOpenApi(content) {
   try {
     const result = normalizeOpenApiYaml(content);
-    return { content: result.content, renamed: result.renamed };
+    return {
+      content: result.content,
+      renamed: result.renamed,
+      openapiContractAudit: result.openapiContractAudit
+    };
   } catch {
     return { content, renamed: [] };
   }
@@ -169124,14 +169223,21 @@ function normalizeApiGatewaySpec(body, candidate, reporter) {
     reporter.warning(
       userSafeWarning(`Skipped operationId normalization for ${candidate.id}: ${formatUserSafeError(error3)}`)
     );
-    return body;
+    return { content: body };
   }
-  if (!result.normalized || result.renamed.length === 0) return body;
-  for (const rename2 of result.renamed) {
-    const from = rename2.original === null ? "<missing>" : rename2.original;
-    reporter.info(`operationId normalized: ${candidate.id} ${rename2.method.toUpperCase()} ${rename2.path} \`${from}\` -> \`${rename2.renamed}\``);
+  if (result.normalized) {
+    for (const rename2 of result.renamed) {
+      const from = rename2.original === null ? "<missing>" : rename2.original;
+      reporter.info(`operationId normalized: ${candidate.id} ${rename2.method.toUpperCase()} ${rename2.path} \`${from}\` -> \`${rename2.renamed}\``);
+    }
   }
-  return result.content;
+  const contractWarning = result.openapiContractAudit ? formatOpenApiContractAuditWarning(result.openapiContractAudit) : void 0;
+  if (contractWarning) reporter.warning(userSafeWarning(contractWarning));
+  return {
+    content: result.normalized ? result.content : body,
+    openapiContractAudit: result.openapiContractAudit,
+    contractWarning
+  };
 }
 async function exportApiGatewaySpecBody(aws, candidate, stage) {
   try {
@@ -169489,6 +169595,7 @@ async function exportProviderResolutionCandidate(resolved, inputs, writeSpecFile
     specFormat: result.format,
     metadataPath: relativeMetadataPath,
     stage: result.stage,
+    openapiContractAudit: inputs.dryRun ? void 0 : result.openapiContractAudit,
     ...derivedOpenApi,
     evidence: [...resolved.evidence, ...result.evidence, ...inputs.dryRun ? ["Dry run enabled; skipped provider spec file write"] : []]
   };
@@ -169656,7 +169763,8 @@ async function runDiscovery(inputs, dependencies) {
         }
         const exportedStage = stage ?? "";
         const exported = await exportApiGatewaySpecBody(dependencies.aws, candidate, exportedStage);
-        const specBody = normalizeApiGatewaySpec(exported.content, candidate, dependencies.core);
+        const normalized = normalizeApiGatewaySpec(exported.content, candidate, dependencies.core);
+        const specBody = normalized.content;
         const derivedOpenApi = await writeResolvedArtifactWithDerivedOpenApi({
           repoRoot: resolvedRoot,
           relativeDir: import_node_path14.default.dirname(relativeSpecPath).replace(/\\/g, "/"),
@@ -169679,6 +169787,7 @@ async function runDiscovery(inputs, dependencies) {
           stage: exportedStage,
           providerType: "api-gateway",
           specFormat: "openapi-yaml",
+          openapiContractAudit: normalized.openapiContractAudit,
           ...derivedOpenApi
         });
         for (const evidence of exported.evidence) {
@@ -169971,11 +170080,12 @@ async function runResolution(inputs, awsClient, actionCore, writeSpecFile, resol
         { id: selectedSource.gatewayId, gatewayType: selectedSource.gatewayType },
         selectedSource.gatewayType === "REST" ? selectedSource.stage : stageSelection.useLatestConfig ? void 0 : selectedSource.stage
       );
-      const body = normalizeApiGatewaySpec(
+      const normalized = normalizeApiGatewaySpec(
         exported.content,
         { id: selectedSource.gatewayId, gatewayType: selectedSource.gatewayType, name: selectedSource.serviceName },
         actionCore
       );
+      const body = normalized.content;
       const derivedOpenApi = await writeResolvedArtifactWithDerivedOpenApi({
         repoRoot: inputs.repoRoot,
         relativeDir: import_node_path14.default.dirname(relativeSpecPath).replace(/\\/g, "/"),
@@ -169992,6 +170102,7 @@ async function runResolution(inputs, awsClient, actionCore, writeSpecFile, resol
       selectedSource.specPath = relativeSpecPath;
       selectedSource.providerType = "api-gateway";
       selectedSource.specFormat = "openapi-yaml";
+      selectedSource.openapiContractAudit = normalized.openapiContractAudit;
       Object.assign(selectedSource, derivedOpenApi);
       if (selectedSource.gatewayType === "WEBSOCKET") {
         selectedSource.evidence = [
@@ -170001,6 +170112,9 @@ async function runResolution(inputs, awsClient, actionCore, writeSpecFile, resol
       }
       if (exported.evidence.length > 0) {
         selectedSource.evidence = [...selectedSource.evidence, ...exported.evidence];
+      }
+      if (normalized.contractWarning) {
+        selectedSource.evidence = [...selectedSource.evidence, normalized.contractWarning];
       }
     } catch (error3) {
       const parsed = parseAwsError(error3);
@@ -170168,6 +170282,8 @@ async function runMultiProviderDiscovery(providers, inputs, dependencies, snsRes
             } catch {
             }
           }
+          const contractWarning = result.openapiContractAudit ? formatOpenApiContractAuditWarning(result.openapiContractAudit) : void 0;
+          if (contractWarning) dependencies.core.warning(userSafeWarning(contractWarning));
           discovered.push({
             serviceName,
             specPath: relativeSpecPath,
@@ -170179,6 +170295,7 @@ async function runMultiProviderDiscovery(providers, inputs, dependencies, snsRes
             contractOrigin,
             variantCount,
             metadataPath: metadataSidecar ? import_node_path14.default.join(inputs.outputDir, folderName, metadataSidecar.filename).replace(/\\/g, "/") : void 0,
+            openapiContractAudit: result.openapiContractAudit,
             ...derivedOpenApi
           });
           dependencies.core.info(`Exported ${provider.type} candidate ${candidate.id} (${candidate.name}) to ${relativeSpecPath}`);
@@ -170371,7 +170488,7 @@ function computeSessionRetryDelayMs(response, attempt, random) {
   const ceiling = Math.min(SESSION_RETRY_MAX_DELAY_MS, SESSION_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1));
   return Math.round(random() * ceiling);
 }
-function asRecord(value) {
+function asRecord2(value) {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return void 0;
   }
@@ -170426,17 +170543,17 @@ async function resolveTelemetryAccountType(accessToken, fetchImpl) {
 async function parseSessionResponse(response) {
   let payload2;
   try {
-    payload2 = asRecord(await response.json());
+    payload2 = asRecord2(await response.json());
   } catch {
     return void 0;
   }
   if (!payload2) {
     return void 0;
   }
-  const root5 = asRecord(payload2.session) ?? payload2;
-  const identity = asRecord(root5.identity);
-  const data2 = asRecord(root5.data);
-  const user = asRecord(data2?.user);
+  const root5 = asRecord2(payload2.session) ?? payload2;
+  const identity = asRecord2(root5.identity);
+  const data2 = asRecord2(root5.data);
+  const user = asRecord2(data2?.user);
   const roleEntries = Array.isArray(user?.roles) ? user.roles.map((entry) => coerceText(entry) ?? coerceId(entry)).filter((entry) => Boolean(entry)) : [];
   const singleRole = coerceText(user?.role);
   const roles = roleEntries.length > 0 ? roleEntries : singleRole ? [singleRole] : void 0;
@@ -171154,6 +171271,7 @@ var outputNames = contractOutputNames;
   LambdaUrlProvider,
   StepFunctionsProvider,
   VerifiedPermissionsProvider,
+  auditOpenApiContractCoverage,
   buildExecutionOutputs,
   buildProviderRegistry,
   collectRepoSignals,
@@ -171161,6 +171279,7 @@ var outputNames = contractOutputNames;
   deriveOpenApiDocument,
   detectCatalogApis,
   execute,
+  formatOpenApiContractAuditWarning,
   getInput,
   normalizeOpenApiYaml,
   outputNames,

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -63,6 +63,29 @@ The action also detects Backstage `catalog-info.yaml` files in the repo root or 
 
 Native artifacts are preserved as the primary output. The action also emits `openapi.derived.json` when it can represent the selected artifact as OpenAPI for downstream onboarding and review. Canonical derived sidecars are always parseable JSON; GraphQL-derived sidecars preserve operation names, variable shapes, and schema components, AsyncAPI-derived sidecars preserve channel payload schemas, examples, and `x-asyncapi-*` channel metadata, Postman-derived sidecars preserve request parameters, JSON examples, auth metadata, and response examples when present, and JSON Schema/Avro-derived sidecars preserve named component schemas with `$ref` request bodies. Provider-specific sidecars such as SNS `webhook.openapi.json` remain separate. See [`validation/evidence/README.md`](../validation/evidence/README.md) for the current evidence ledger.
 
+## API Gateway contract coverage
+
+API Gateway exports routes and status declarations even when the API has no request or response models. In that case the exported OpenAPI can omit response `content` or include media types without schemas. Omission means the body contract is undocumented, not that the live response must be empty.
+
+For each actual API Gateway export, the action records `openapiContractAudit` inside the existing `resolution-json` output or each API Gateway entry in `services-json`:
+
+```json
+{
+  "schemaVersion": 1,
+  "status": "schema-incomplete",
+  "operationCount": 1,
+  "responseCount": 1,
+  "responsesWithoutContent": 1,
+  "responseMediaTypesWithoutSchema": 0,
+  "requestMediaTypesWithoutSchema": 0,
+  "defaultOnlyOperationCount": 1
+}
+```
+
+`AWS_OPENAPI_CONTRACT_INCOMPLETE` is advisory. Downstream bootstrap still enforces documented routes and status codes, but it does not invent empty-body or schema assertions where the export has no body contract. Define API Gateway models or enrich the source OpenAPI when request and response body schemas must be strict CI gates.
+
+This audit is independent of `derived-openapi-completeness`. Derived completeness describes how faithfully the selected artifact was represented as the canonical OpenAPI sidecar; it does not claim that the source API documented every request or response schema. Dry runs, non-OpenAPI payloads, and non-API-Gateway providers do not receive a guessed audit.
+
 ## Security and IAM
 
 This action is read-only against AWS APIs and does not mutate AWS resources.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-aws-spec-discovery",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-aws-spec-discovery",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-aws-spec-discovery",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Discover AWS-hosted API specs and hand the result to Postman API onboarding.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -78,6 +78,17 @@ export type DerivedOpenApiCompleteness = 'full' | 'partial';
 
 export type DerivedOpenApiFormat = 'openapi-json' | 'openapi-yaml';
 
+export interface OpenApiContractAudit {
+  schemaVersion: 1;
+  status: 'schema-complete' | 'schema-incomplete';
+  operationCount: number;
+  responseCount: number;
+  responsesWithoutContent: number;
+  responseMediaTypesWithoutSchema: number;
+  requestMediaTypesWithoutSchema: number;
+  defaultOnlyOperationCount: number;
+}
+
 export interface ResolvedServiceCandidate {
   serviceName: string;
   gatewayId: string;
@@ -107,6 +118,7 @@ export interface ResolutionResult {
   derivedOpenApiCompleteness?: DerivedOpenApiCompleteness;
   derivedOpenApiFormat?: DerivedOpenApiFormat;
   derivedOpenApiEvidence?: string[];
+  openapiContractAudit?: OpenApiContractAudit;
   evidence: string[];
 }
 
@@ -126,6 +138,7 @@ export interface DiscoveredService {
   derivedOpenApiCompleteness?: DerivedOpenApiCompleteness;
   derivedOpenApiFormat?: DerivedOpenApiFormat;
   derivedOpenApiEvidence?: string[];
+  openapiContractAudit?: OpenApiContractAudit;
 }
 
 export const actionContract: AwsSpecDiscoveryActionContract = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,6 +118,8 @@ if (entrypoint && currentModulePath === entrypoint) {
 
 export * from './runtime.js';
 export {
+  auditOpenApiContractCoverage,
+  formatOpenApiContractAuditWarning,
   normalizeOpenApiYaml,
   type OperationIdRename,
   type NormalizeOpenApiResult

--- a/src/lib/providers/api-gateway.ts
+++ b/src/lib/providers/api-gateway.ts
@@ -1,6 +1,6 @@
-import type { GatewayType } from '../../contracts.js';
+import type { GatewayType, OpenApiContractAudit } from '../../contracts.js';
 import { parseAwsError, type AwsGatewayClient, type HttpApiSummary, type RestApiSummary } from '../aws/client.js';
-import { normalizeOpenApiYaml } from '../spec/normalize-openapi.js';
+import { formatOpenApiContractAuditWarning, normalizeOpenApiYaml } from '../spec/normalize-openapi.js';
 import type { ExportOptions, SpecCandidate, SpecExportResult, SpecProvider } from './types.js';
 
 export interface ApiGatewayProviderOptions {
@@ -117,6 +117,10 @@ export class ApiGatewayProvider implements SpecProvider {
         }
       }
     }
+    const contractWarning = normalized.openapiContractAudit
+      ? formatOpenApiContractAuditWarning(normalized.openapiContractAudit)
+      : undefined;
+    if (contractWarning) evidence.push(contractWarning);
 
     return {
       content: normalized.content,
@@ -124,6 +128,7 @@ export class ApiGatewayProvider implements SpecProvider {
       filename: 'index.yaml',
       stage,
       derivedOpenApiCompleteness: exported.fallback || gatewayType === 'WEBSOCKET' ? 'partial' : undefined,
+      openapiContractAudit: normalized.openapiContractAudit,
       evidence
     };
   }
@@ -175,10 +180,18 @@ function isKnownRestExportLimitation(message: string): boolean {
 // If we throw here the export step fails outright, which is strictly
 // worse than letting the original spec through and letting bootstrap's
 // validator surface the underlying problem.
-function safeNormalizeOpenApi(content: string): { content: string; renamed: { path: string; method: string; original: string | null; renamed: string }[] } {
+function safeNormalizeOpenApi(content: string): {
+  content: string;
+  renamed: { path: string; method: string; original: string | null; renamed: string }[];
+  openapiContractAudit?: OpenApiContractAudit;
+} {
   try {
     const result = normalizeOpenApiYaml(content);
-    return { content: result.content, renamed: result.renamed };
+    return {
+      content: result.content,
+      renamed: result.renamed,
+      openapiContractAudit: result.openapiContractAudit
+    };
   } catch {
     return { content, renamed: [] };
   }

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -1,4 +1,4 @@
-import type { DerivedOpenApiCompleteness, ProviderType, SpecFormat } from '../../contracts.js';
+import type { DerivedOpenApiCompleteness, OpenApiContractAudit, ProviderType, SpecFormat } from '../../contracts.js';
 
 export interface SpecCandidate {
   id: string;
@@ -25,6 +25,7 @@ export interface SpecExportResult {
   stage?: string;
   evidence: string[];
   derivedOpenApiCompleteness?: DerivedOpenApiCompleteness;
+  openapiContractAudit?: OpenApiContractAudit;
   sidecars?: Array<{
     filename: string;
     content: string;

--- a/src/lib/spec/normalize-openapi.ts
+++ b/src/lib/spec/normalize-openapi.ts
@@ -1,7 +1,7 @@
 // Normalize OpenAPI specs exported by AWS to satisfy validator requirements
 // that the AWS export pipeline does not enforce.
 //
-// Today this handles one rule:
+// It handles two independent concerns:
 //
 //   "Every operation must have a unique operationId" -- OpenAPI 3.x spec
 //
@@ -29,9 +29,11 @@
 //
 // We use `yaml`'s document-level API so quoting, ordering, and the bits of
 // formatting AWS emits are preserved -- the only diff is the operationId
-// values themselves.
+// values themselves. It also records whether the exported document contains
+// enough request/response schema detail for downstream body-contract checks.
 
 import { isMap, isScalar, parseDocument, type Document, type Scalar, type YAMLMap } from 'yaml';
+import type { OpenApiContractAudit } from '../../contracts.js';
 
 const HTTP_METHODS = new Set(['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']);
 
@@ -47,6 +49,126 @@ export interface NormalizeOpenApiResult {
   renamed: OperationIdRename[];
   /** True if the document was recognized as an OpenAPI spec and walked. */
   normalized: boolean;
+  openapiContractAudit?: OpenApiContractAudit;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): JsonRecord | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as JsonRecord
+    : undefined;
+}
+
+function resolveLocalObject(root: JsonRecord, value: unknown): JsonRecord | undefined {
+  let current = asRecord(value);
+  const seen = new Set<JsonRecord>();
+  while (current && typeof current.$ref === 'string') {
+    if (seen.has(current) || !current.$ref.startsWith('#/')) return undefined;
+    seen.add(current);
+    let resolved: unknown = root;
+    for (const rawSegment of current.$ref.slice(2).split('/')) {
+      const segment = rawSegment.replace(/~1/g, '/').replace(/~0/g, '~');
+      resolved = asRecord(resolved)?.[segment];
+    }
+    current = asRecord(resolved);
+  }
+  return current;
+}
+
+function responseIsStaticallyBodyless(method: string, status: string): boolean {
+  const normalized = status.toUpperCase();
+  return method === 'head'
+    || normalized === '1XX'
+    || /^1[0-9][0-9]$/.test(normalized)
+    || normalized === '204'
+    || normalized === '205'
+    || normalized === '304';
+}
+
+function isResponseDeclarationKey(value: string): boolean {
+  return value.toLowerCase() === 'default' || /^[1-5](?:[0-9]{2}|xx)$/i.test(value);
+}
+
+export function auditOpenApiContractCoverage(value: unknown): OpenApiContractAudit | undefined {
+  const root = asRecord(value);
+  const paths = asRecord(root?.paths);
+  if (!root || typeof root.openapi !== 'string' || !/^3\./.test(root.openapi) || !paths) return undefined;
+
+  const audit: OpenApiContractAudit = {
+    schemaVersion: 1,
+    status: 'schema-complete',
+    operationCount: 0,
+    responseCount: 0,
+    responsesWithoutContent: 0,
+    responseMediaTypesWithoutSchema: 0,
+    requestMediaTypesWithoutSchema: 0,
+    defaultOnlyOperationCount: 0
+  };
+
+  for (const rawPathItem of Object.values(paths)) {
+    const pathItem = resolveLocalObject(root, rawPathItem);
+    if (!pathItem) return undefined;
+    for (const [rawMethod, rawOperation] of Object.entries(pathItem)) {
+      const method = rawMethod.toLowerCase();
+      if (!HTTP_METHODS.has(method)) continue;
+      const operation = resolveLocalObject(root, rawOperation);
+      if (!operation) return undefined;
+      audit.operationCount += 1;
+
+      const requestBody = operation.requestBody === undefined
+        ? undefined
+        : resolveLocalObject(root, operation.requestBody);
+      if (operation.requestBody !== undefined && !requestBody) return undefined;
+      const requestContent = asRecord(requestBody?.content);
+      for (const rawMedia of Object.values(requestContent ?? {})) {
+        const media = asRecord(rawMedia);
+        if (!media) return undefined;
+        if (media.schema === undefined) audit.requestMediaTypesWithoutSchema += 1;
+      }
+
+      const responses = asRecord(operation.responses);
+      if (!responses) return undefined;
+      const responseKeys = Object.keys(responses).filter(isResponseDeclarationKey);
+      if (responseKeys.length === 0) return undefined;
+      if (responseKeys.some((status) => status.toLowerCase() === 'default') && responseKeys.length === 1) {
+        audit.defaultOnlyOperationCount += 1;
+      }
+      for (const status of responseKeys) {
+        const rawResponse = responses[status];
+        audit.responseCount += 1;
+        const response = resolveLocalObject(root, rawResponse);
+        if (!response) return undefined;
+        const content = asRecord(response?.content);
+        if ((!content || Object.keys(content).length === 0) && !responseIsStaticallyBodyless(method, status)) {
+          audit.responsesWithoutContent += 1;
+        }
+        for (const rawMedia of Object.values(content ?? {})) {
+          const media = asRecord(rawMedia);
+          if (!media) return undefined;
+          if (media.schema === undefined) audit.responseMediaTypesWithoutSchema += 1;
+        }
+      }
+    }
+  }
+
+  if (
+    audit.responsesWithoutContent > 0
+    || audit.responseMediaTypesWithoutSchema > 0
+    || audit.requestMediaTypesWithoutSchema > 0
+  ) {
+    audit.status = 'schema-incomplete';
+  }
+  return audit;
+}
+
+export function formatOpenApiContractAuditWarning(audit: OpenApiContractAudit): string | undefined {
+  if (audit.status !== 'schema-incomplete') return undefined;
+  return 'AWS_OPENAPI_CONTRACT_INCOMPLETE: API Gateway export has '
+    + `${audit.responsesWithoutContent} response declaration(s) without content, `
+    + `${audit.responseMediaTypesWithoutSchema} response media declaration(s) without schema, and `
+    + `${audit.requestMediaTypesWithoutSchema} request media declaration(s) without schema. `
+    + 'Bootstrap keeps route and status checks but skips undocumented body assertions; define API Gateway models or enrich the OpenAPI before treating body-schema tests as strict CI gates.';
 }
 
 /**
@@ -120,11 +242,12 @@ export function normalizeOpenApiYaml(content: string): NormalizeOpenApiResult {
     }
   }
 
+  const openapiContractAudit = auditOpenApiContractCoverage(doc.toJS());
   if (renamed.length === 0) {
-    return { content, renamed: [], normalized: true };
+    return { content, renamed: [], normalized: true, openapiContractAudit };
   }
 
-  return { content: String(doc), renamed, normalized: true };
+  return { content: String(doc), renamed, normalized: true, openapiContractAudit };
 }
 
 function scalarString(node: unknown): string | undefined {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -7,6 +7,7 @@ import {
   type ActionMode,
   type DiscoveredService,
   type GatewayType,
+  type OpenApiContractAudit,
   type ProviderType,
   type ResolutionResult,
   type SourceType,
@@ -31,7 +32,11 @@ import { findExistingRepoSpecTyped } from './lib/repo/specs.js';
 import { collectRepoSignals } from './lib/repo/signals.js';
 import { chooseSource } from './lib/resolve/source-selector.js';
 import { resolveServiceCandidate } from './lib/resolve/service-resolver.js';
-import { normalizeOpenApiYaml, type OperationIdRename } from './lib/spec/normalize-openapi.js';
+import {
+  formatOpenApiContractAuditWarning,
+  normalizeOpenApiYaml,
+  type OperationIdRename
+} from './lib/spec/normalize-openapi.js';
 import { deriveOpenApiDocument, type OpenApiDerivationResult } from './lib/spec/oas-derivation.js';
 import { ProviderRegistry } from './lib/providers/registry.js';
 import { ApiGatewayProvider } from './lib/providers/api-gateway.js';
@@ -505,23 +510,36 @@ function normalizeApiGatewaySpec(
   body: string,
   candidate: { id: string; gatewayType?: GatewayType; name?: string },
   reporter: Pick<ReporterLike, 'info' | 'warning'>
-): string {
-  let result: { content: string; renamed: OperationIdRename[]; normalized: boolean };
+): { content: string; openapiContractAudit?: OpenApiContractAudit; contractWarning?: string } {
+  let result: {
+    content: string;
+    renamed: OperationIdRename[];
+    normalized: boolean;
+    openapiContractAudit?: OpenApiContractAudit;
+  };
   try {
     result = normalizeOpenApiYaml(body);
   } catch (error) {
     reporter.warning(
       userSafeWarning(`Skipped operationId normalization for ${candidate.id}: ${formatUserSafeError(error)}`)
     );
-    return body;
+    return { content: body };
   }
-  if (!result.normalized || result.renamed.length === 0) return body;
-
-  for (const rename of result.renamed) {
-    const from = rename.original === null ? '<missing>' : rename.original;
-    reporter.info(`operationId normalized: ${candidate.id} ${rename.method.toUpperCase()} ${rename.path} \`${from}\` -> \`${rename.renamed}\``);
+  if (result.normalized) {
+    for (const rename of result.renamed) {
+      const from = rename.original === null ? '<missing>' : rename.original;
+      reporter.info(`operationId normalized: ${candidate.id} ${rename.method.toUpperCase()} ${rename.path} \`${from}\` -> \`${rename.renamed}\``);
+    }
   }
-  return result.content;
+  const contractWarning = result.openapiContractAudit
+    ? formatOpenApiContractAuditWarning(result.openapiContractAudit)
+    : undefined;
+  if (contractWarning) reporter.warning(userSafeWarning(contractWarning));
+  return {
+    content: result.normalized ? result.content : body,
+    openapiContractAudit: result.openapiContractAudit,
+    contractWarning
+  };
 }
 
 async function exportApiGatewaySpecBody(
@@ -951,6 +969,7 @@ async function exportProviderResolutionCandidate(
     specFormat: result.format,
     metadataPath: relativeMetadataPath,
     stage: result.stage,
+    openapiContractAudit: inputs.dryRun ? undefined : result.openapiContractAudit,
     ...derivedOpenApi,
     evidence: [...resolved.evidence, ...result.evidence, ...(inputs.dryRun ? ['Dry run enabled; skipped provider spec file write'] : [])]
   };
@@ -1134,7 +1153,8 @@ export async function runDiscovery(inputs: ResolvedInputs, dependencies: Discove
 
         const exportedStage = stage ?? '';
         const exported = await exportApiGatewaySpecBody(dependencies.aws, candidate, exportedStage);
-        const specBody = normalizeApiGatewaySpec(exported.content, candidate, dependencies.core);
+        const normalized = normalizeApiGatewaySpec(exported.content, candidate, dependencies.core);
+        const specBody = normalized.content;
         const derivedOpenApi = await writeResolvedArtifactWithDerivedOpenApi({
           repoRoot: resolvedRoot,
           relativeDir: path.dirname(relativeSpecPath).replace(/\\/g, '/'),
@@ -1157,6 +1177,7 @@ export async function runDiscovery(inputs: ResolvedInputs, dependencies: Discove
           stage: exportedStage,
           providerType: 'api-gateway',
           specFormat: 'openapi-yaml',
+          openapiContractAudit: normalized.openapiContractAudit,
           ...derivedOpenApi
         });
         for (const evidence of exported.evidence) {
@@ -1497,11 +1518,12 @@ export async function runResolution(
           ? selectedSource.stage
           : stageSelection.useLatestConfig ? undefined : selectedSource.stage
       );
-      const body = normalizeApiGatewaySpec(
+      const normalized = normalizeApiGatewaySpec(
         exported.content,
         { id: selectedSource.gatewayId, gatewayType: selectedSource.gatewayType, name: selectedSource.serviceName },
         actionCore
       );
+      const body = normalized.content;
       const derivedOpenApi = await writeResolvedArtifactWithDerivedOpenApi({
         repoRoot: inputs.repoRoot,
         relativeDir: path.dirname(relativeSpecPath).replace(/\\/g, '/'),
@@ -1518,6 +1540,7 @@ export async function runResolution(
       selectedSource.specPath = relativeSpecPath;
       selectedSource.providerType = 'api-gateway';
       selectedSource.specFormat = 'openapi-yaml';
+      selectedSource.openapiContractAudit = normalized.openapiContractAudit;
       Object.assign(selectedSource, derivedOpenApi);
       if (selectedSource.gatewayType === 'WEBSOCKET') {
         selectedSource.evidence = [
@@ -1527,6 +1550,9 @@ export async function runResolution(
       }
       if (exported.evidence.length > 0) {
         selectedSource.evidence = [...selectedSource.evidence, ...exported.evidence];
+      }
+      if (normalized.contractWarning) {
+        selectedSource.evidence = [...selectedSource.evidence, normalized.contractWarning];
       }
     } catch (error) {
       const parsed = parseAwsError(error);
@@ -1715,6 +1741,10 @@ async function runMultiProviderDiscovery(
               // ignore malformed metadata sidecar
             }
           }
+          const contractWarning = result.openapiContractAudit
+            ? formatOpenApiContractAuditWarning(result.openapiContractAudit)
+            : undefined;
+          if (contractWarning) dependencies.core.warning(userSafeWarning(contractWarning));
           discovered.push({
             serviceName,
             specPath: relativeSpecPath,
@@ -1722,12 +1752,13 @@ async function runMultiProviderDiscovery(
             gatewayType,
             stage: result.stage ?? '',
             providerType: provider.type,
-	            specFormat: result.format,
-	            contractOrigin,
-	            variantCount,
-	            metadataPath: metadataSidecar ? path.join(inputs.outputDir, folderName, metadataSidecar.filename).replace(/\\/g, '/') : undefined,
-	            ...derivedOpenApi
-	          });
+            specFormat: result.format,
+            contractOrigin,
+            variantCount,
+            metadataPath: metadataSidecar ? path.join(inputs.outputDir, folderName, metadataSidecar.filename).replace(/\\/g, '/') : undefined,
+            openapiContractAudit: result.openapiContractAudit,
+            ...derivedOpenApi
+          });
           dependencies.core.info(`Exported ${provider.type} candidate ${candidate.id} (${candidate.name}) to ${relativeSpecPath}`);
         } catch (error) {
           summary.failed += 1;

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -125,7 +125,19 @@ describe('runCli integration boundary', () => {
         mode: 'resolve-one',
         discovered: [],
         outputs: {
-          'resolution-json': '{"status":"resolved"}',
+          'resolution-json': JSON.stringify({
+            status: 'resolved',
+            openapiContractAudit: {
+              schemaVersion: 1,
+              status: 'schema-incomplete',
+              operationCount: 1,
+              responseCount: 1,
+              responsesWithoutContent: 1,
+              responseMediaTypesWithoutSchema: 0,
+              requestMediaTypesWithoutSchema: 0,
+              defaultOnlyOperationCount: 1
+            }
+          }),
           'resolution-status': 'resolved',
           'source-type': 'repo-spec',
           'mapping-confidence': '90',
@@ -148,6 +160,7 @@ describe('runCli integration boundary', () => {
       const resultJson = await readFile(path.join(tempDir, 'result.json'), 'utf8');
       const dotenv = await readFile(path.join(tempDir, 'result.env'), 'utf8');
       expect(resultJson).toContain('"mode": "resolve-one"');
+      expect(JSON.parse(resultJson).outputs['resolution-json']).toContain('"openapiContractAudit"');
       expect(dotenv).toContain('POSTMAN_AWS_SPEC_RESOLUTION_STATUS=');
       expect(dotenv).toContain('POSTMAN_AWS_SPEC_EXPORT_SUMMARY_JSON=');
     } finally {

--- a/tests/discovery.test.ts
+++ b/tests/discovery.test.ts
@@ -467,6 +467,7 @@ describe('runDiscovery', () => {
       expect(result.specPath).toBe('discovered-specs/orders-api/index.yaml');
       expect(result.derivedOpenApiPath).toBe('discovered-specs/orders-api/openapi.derived.json');
       expect(result.derivedOpenApiFormat).toBe('openapi-json');
+      expect(result.openapiContractAudit).toBeUndefined();
       expect(result.derivedOpenApiEvidence).toEqual(expect.arrayContaining([expect.stringContaining('Dry run enabled')]));
       expect(aws.exportRestApi).not.toHaveBeenCalled();
       expect(writeSpecFile).not.toHaveBeenCalled();
@@ -1150,7 +1151,7 @@ describe('SNS runtime integration', () => {
   });
 
   it('includes SNS results in discover-many services output', async () => {
-    const { core } = createCoreStub();
+    const { core, warnings } = createCoreStub();
     const snsProvider = createDiscoverManySnsProvider({
       listCandidates: vi.fn().mockResolvedValue([createSnsTopicCandidate('orders-topic')])
     });
@@ -1159,7 +1160,15 @@ describe('SNS runtime integration', () => {
     const awsClient = createAwsClientStub({
       listRestApis: vi.fn().mockResolvedValue([{ id: 'rest-1', name: 'orders-api' }]),
       listRestStages: vi.fn().mockResolvedValue(['prod']),
-      exportRestApi: vi.fn().mockResolvedValue('openapi: 3.0.1')
+      exportRestApi: vi.fn().mockResolvedValue([
+        'openapi: 3.0.3',
+        'info: { title: orders-api, version: "1" }',
+        'paths:',
+        '  /health:',
+        '    get:',
+        '      responses:',
+        '        default: { description: Default response }'
+      ].join('\n'))
     });
 
     const result = await execute(
@@ -1192,9 +1201,23 @@ describe('SNS runtime integration', () => {
     const providerTypes = result.discovered.map((entry) => entry.providerType);
     expect(providerTypes).toContain('api-gateway');
     expect(providerTypes).toContain('sns');
-    const services = JSON.parse(result.outputs['services-json'] ?? '[]') as Array<{ providerType?: string }>;
+    const services = JSON.parse(result.outputs['services-json'] ?? '[]') as Array<{
+      providerType?: string;
+      openapiContractAudit?: DiscoveredService['openapiContractAudit'];
+    }>;
     expect(services.map((entry) => entry.providerType)).toContain('api-gateway');
     expect(services.map((entry) => entry.providerType)).toContain('sns');
+    const discoveredGateway = result.discovered.find((entry) => entry.providerType === 'api-gateway');
+    const outputGateway = services.find((entry) => entry.providerType === 'api-gateway');
+    expect(discoveredGateway?.openapiContractAudit).toMatchObject({
+      schemaVersion: 1,
+      status: 'schema-incomplete',
+      responsesWithoutContent: 1,
+      defaultOnlyOperationCount: 1
+    });
+    expect(outputGateway?.openapiContractAudit).toEqual(discoveredGateway?.openapiContractAudit);
+    expect(services.find((entry) => entry.providerType === 'sns')?.openapiContractAudit).toBeUndefined();
+    expect(warnings.filter((message) => message.startsWith('AWS_OPENAPI_CONTRACT_INCOMPLETE:'))).toHaveLength(1);
   });
 
   it('writes SNS metadata sidecar in discover-many and records metadataPath', async () => {
@@ -1876,7 +1899,7 @@ describe('provider-agnostic resolve-one', () => {
 describe('runAction', () => {
   it('emits resolution outputs in resolve-one mode', async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), 'run-action-resolution-'));
-    const { core, outputs } = createCoreStub({
+    const { core, outputs, warnings } = createCoreStub({
       'aws-region': 'us-east-1',
       'gateway-id': 'rest-1'
     });
@@ -1887,7 +1910,15 @@ describe('runAction', () => {
       getRestApi: vi.fn().mockResolvedValue({ id: 'rest-1', name: 'billing' }),
       getRestTags: vi.fn().mockResolvedValue({}),
       listRestStages: vi.fn().mockResolvedValue(['prod']),
-      exportRestApi: vi.fn().mockResolvedValue('openapi: 3.0.1\ninfo:\n  title: billing')
+      exportRestApi: vi.fn().mockResolvedValue([
+        'openapi: 3.0.3',
+        'info: { title: billing, version: "1" }',
+        'paths:',
+        '  /health:',
+        '    get:',
+        '      responses:',
+        '        default: { description: Default response }'
+      ].join('\n'))
     });
 
     try {
@@ -1909,7 +1940,20 @@ describe('runAction', () => {
       expect(outputs['spec-format']).toBe('openapi-yaml');
       expect(outputs['export-summary-json']).toContain('"attempted":0');
       expect([...written.keys()].some((entry) => entry.endsWith('/discovered-specs/billing/index.yaml'))).toBe(true);
-      expect(() => JSON.parse(outputs['resolution-json'] ?? '{}')).not.toThrow();
+      const resolution = JSON.parse(outputs['resolution-json'] ?? '{}') as {
+        evidence?: string[];
+        openapiContractAudit?: DiscoveredService['openapiContractAudit'];
+      };
+      expect(resolution.openapiContractAudit).toMatchObject({
+        schemaVersion: 1,
+        status: 'schema-incomplete',
+        responsesWithoutContent: 1,
+        defaultOnlyOperationCount: 1
+      });
+      expect(resolution.evidence).toEqual(expect.arrayContaining([
+        expect.stringContaining('AWS_OPENAPI_CONTRACT_INCOMPLETE:')
+      ]));
+      expect(warnings.filter((message) => message.startsWith('AWS_OPENAPI_CONTRACT_INCOMPLETE:'))).toHaveLength(1);
     } finally {
       if (previousWorkspace === undefined) {
         delete process.env.GITHUB_WORKSPACE;

--- a/tests/normalize-openapi.test.ts
+++ b/tests/normalize-openapi.test.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it, vi } from 'vitest';
 import { parse } from 'yaml';
 
-import { normalizeOpenApiYaml } from '../src/lib/spec/normalize-openapi.js';
+import { auditOpenApiContractCoverage, normalizeOpenApiYaml } from '../src/lib/spec/normalize-openapi.js';
 import { ApiGatewayProvider } from '../src/lib/providers/api-gateway.js';
 import type { AwsGatewayClient } from '../src/lib/aws/client.js';
 
@@ -163,6 +163,180 @@ describe('normalizeOpenApiYaml', () => {
     // The renamed entry should preserve `update` as the base.
     const renamedCopies = ids.filter((id) => id !== 'update' && id.startsWith('update'));
     expect(renamedCopies.length).toBeGreaterThan(0);
+  });
+});
+
+describe('auditOpenApiContractCoverage', () => {
+  it('classifies an AWS-style default-only route response without content as schema-incomplete', () => {
+    const audit = auditOpenApiContractCoverage({
+      openapi: '3.0.3',
+      paths: {
+        '/health': {
+          get: {
+            responses: {
+              default: { description: 'Default response' }
+            }
+          }
+        }
+      }
+    });
+
+    expect(audit).toEqual({
+      schemaVersion: 1,
+      status: 'schema-incomplete',
+      operationCount: 1,
+      responseCount: 1,
+      responsesWithoutContent: 1,
+      responseMediaTypesWithoutSchema: 0,
+      requestMediaTypesWithoutSchema: 0,
+      defaultOnlyOperationCount: 1
+    });
+  });
+
+  it('counts declared request and response media entries without schemas', () => {
+    const audit = auditOpenApiContractCoverage({
+      openapi: '3.0.3',
+      paths: {
+        '/orders': {
+          post: {
+            requestBody: { content: { 'application/json': {} } },
+            responses: {
+              '200': {
+                description: 'OK',
+                content: { 'application/json': {}, 'application/problem+json': { schema: { type: 'object' } } }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    expect(audit).toMatchObject({
+      status: 'schema-incomplete',
+      operationCount: 1,
+      responseCount: 1,
+      responsesWithoutContent: 0,
+      responseMediaTypesWithoutSchema: 1,
+      requestMediaTypesWithoutSchema: 1,
+      defaultOnlyOperationCount: 0
+    });
+  });
+
+  it('exempts HEAD, 1xx, 1XX, 204, 205, and 304 response declarations without content', () => {
+    const audit = auditOpenApiContractCoverage({
+      openapi: '3.1.0',
+      paths: {
+        '/head': {
+          head: { responses: { '200': { description: 'Representation metadata' }, default: { description: 'Default' } } }
+        },
+        '/status': {
+          get: {
+            responses: {
+              '101': { description: 'Switching protocols' },
+              '1XX': { description: 'Informational' },
+              '204': { description: 'No content' },
+              '205': { description: 'Reset content' },
+              '304': { description: 'Not modified' }
+            }
+          }
+        }
+      }
+    });
+
+    expect(audit).toMatchObject({
+      status: 'schema-complete',
+      operationCount: 2,
+      responseCount: 7,
+      responsesWithoutContent: 0,
+      responseMediaTypesWithoutSchema: 0,
+      requestMediaTypesWithoutSchema: 0,
+      defaultOnlyOperationCount: 0
+    });
+  });
+
+  it('keeps a schema-rich default-only operation complete while recording the fallback shape', () => {
+    const document = {
+      openapi: '3.0.3',
+      paths: {
+        '/health': {
+          get: {
+            responses: {
+              default: {
+                description: 'Response',
+                content: { 'application/json': { schema: { type: 'object' } } }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    expect(auditOpenApiContractCoverage(document)).toEqual(auditOpenApiContractCoverage(document));
+    expect(auditOpenApiContractCoverage(document)).toMatchObject({
+      status: 'schema-complete',
+      defaultOnlyOperationCount: 1
+    });
+  });
+
+  it('ignores response extensions when identifying a default-only operation', () => {
+    expect(auditOpenApiContractCoverage({
+      openapi: '3.0.3',
+      paths: {
+        '/health': {
+          get: {
+            responses: {
+              default: {
+                description: 'Response',
+                content: { 'application/json': { schema: { type: 'object' } } }
+              },
+              'x-amazon-apigateway-integration': { type: 'mock' }
+            }
+          }
+        }
+      }
+    })).toMatchObject({
+      status: 'schema-complete',
+      responseCount: 1,
+      defaultOnlyOperationCount: 1
+    });
+  });
+
+  it('returns no audit when an operation or response reference cannot be resolved locally', () => {
+    expect(auditOpenApiContractCoverage({
+      openapi: '3.0.3',
+      paths: { '/external': { $ref: 'https://example.invalid/path-item.yaml' } }
+    })).toBeUndefined();
+    expect(auditOpenApiContractCoverage({
+      openapi: '3.0.3',
+      paths: {
+        '/external': {
+          get: { responses: { default: { $ref: 'https://example.invalid/response.yaml' } } }
+        }
+      }
+    })).toBeUndefined();
+  });
+
+  it('returns no audit for malformed or non-OpenAPI input', () => {
+    expect(auditOpenApiContractCoverage(null)).toBeUndefined();
+    expect(auditOpenApiContractCoverage({ paths: {} })).toBeUndefined();
+    expect(auditOpenApiContractCoverage({ openapi: '3.0.3' })).toBeUndefined();
+  });
+
+  it('attaches the audit to normalized OpenAPI output', () => {
+    const normalized = normalizeOpenApiYaml([
+      'openapi: 3.0.3',
+      'info: { title: t, version: v }',
+      'paths:',
+      '  /health:',
+      '    get:',
+      '      responses:',
+      '        default: { description: Default response }'
+    ].join('\n'));
+
+    expect(normalized.openapiContractAudit).toMatchObject({
+      status: 'schema-incomplete',
+      responsesWithoutContent: 1
+    });
   });
 });
 

--- a/tests/providers.test.ts
+++ b/tests/providers.test.ts
@@ -235,6 +235,37 @@ describe('ApiGatewayProvider', () => {
     expect(result.content).toContain('openapi');
   });
 
+  it('attaches a schema-coverage audit and actionable evidence to route-only REST exports', async () => {
+    const client = createGatewayClientStub({
+      exportRestApi: vi.fn().mockResolvedValue([
+        'openapi: 3.0.3',
+        'info: { title: test, version: "1" }',
+        'paths:',
+        '  /health:',
+        '    get:',
+        '      responses:',
+        '        default: { description: Default response }'
+      ].join('\n'))
+    });
+    const provider = new ApiGatewayProvider(client, { includeV2: true });
+
+    const result = await provider.exportSpec(
+      { id: 'rest-1', name: 'test', providerType: 'api-gateway', tags: {}, evidence: [], meta: { gatewayType: 'REST' } },
+      { stage: 'prod' }
+    );
+
+    expect(result.openapiContractAudit).toMatchObject({
+      schemaVersion: 1,
+      status: 'schema-incomplete',
+      responsesWithoutContent: 1,
+      defaultOnlyOperationCount: 1
+    });
+    expect(result.evidence).toEqual(expect.arrayContaining([
+      expect.stringContaining('AWS_OPENAPI_CONTRACT_INCOMPLETE:')
+    ]));
+    expect(result.derivedOpenApiCompleteness).toBeUndefined();
+  });
+
   it('falls back to REST API models and methods when REST export hits a known limitation', async () => {
     const client = createGatewayClientStub({
       exportRestApi: vi.fn().mockRejectedValue(

--- a/validation/README.md
+++ b/validation/README.md
@@ -68,6 +68,8 @@ node validation/scripts/capture-live-manifest.mjs --stack-name spec-discovery-va
 node validation/scripts/validate-live-aws-surfaces.mjs
 ```
 
+API Gateway validation additionally retains an end-to-end route-only receipt: the exported response omits `content`, discovery reports `openapiContractAudit.status = schema-incomplete` with the `AWS_OPENAPI_CONTRACT_INCOMPLETE` warning, and the released bootstrap contract collection passes against the live JSON `/health` response. See `runbooks/api-gateway.md` for the exact evidence fields.
+
 To create or refresh the live AWS stack:
 
 ```bash

--- a/validation/evidence/README.md
+++ b/validation/evidence/README.md
@@ -53,7 +53,7 @@ Raw live identifiers are stored only in `live-resource-manifest.local.json`.
 <!-- evidence:repo-spec-matrix:start -->
 ## Repo Spec Matrix Evidence
 
-- Captured at: 2026-06-01T20:47:14.021Z
+- Captured at: 2026-07-17T22:53:54.693Z
 - Cases: 15
 - Passed: 15
 - Failed: 0
@@ -118,7 +118,7 @@ Raw live identifiers are stored only in `live-resource-manifest.local.json`.
 <!-- evidence:iac-repo-signals-matrix:start -->
 ## IaC and Repo Signal Matrix Evidence
 
-- Captured at: 2026-06-01T20:47:14.231Z
+- Captured at: 2026-07-17T22:53:54.998Z
 - Cases: 8
 - Passed: 8
 - Failed: 0
@@ -138,7 +138,7 @@ Raw live identifiers are stored only in `live-resource-manifest.local.json`.
 <!-- evidence:p3-surfaces:start -->
 ## P3 Surface Fixture Evidence
 
-- Captured at: 2026-06-01T20:47:14.411Z
+- Captured at: 2026-07-17T22:53:55.238Z
 - Cases: 9
 - Passed: 9
 - Failed: 0

--- a/validation/runbooks/api-gateway.md
+++ b/validation/runbooks/api-gateway.md
@@ -21,9 +21,22 @@ node validation/scripts/validate-live-aws-surfaces.mjs
 node validation/scripts/run-cli-surface.mjs --surface discover-many --region us-east-1 --keep-workspace true
 ```
 
+For the route-only REST fixture, retain the CLI result JSON and warning log. Confirm the exported OpenAPI response has no `content`, then verify:
+
+```text
+openapiContractAudit.schemaVersion = 1
+openapiContractAudit.status = schema-incomplete
+openapiContractAudit.responsesWithoutContent >= 1
+warning prefix = AWS_OPENAPI_CONTRACT_INCOMPLETE:
+```
+
+Pass that exact exported spec to the released bootstrap CLI. Run the generated cloud contract collection against the live `/health` route and retain a receipt showing the endpoint returns `{"status":"ok"}`, the contract run exits zero, and the legal nonzero `Content-Length` assertion passes. Do not enrich the fixture with an API Gateway response model for this check; the missing model is the behavior under test.
+
 ## Expected Evidence
 
 - REST API exports OpenAPI 3.0 YAML.
+- Route-only REST exports carry a schema-version-1 `schema-incomplete` audit and the actionable warning without modifying the exported OpenAPI.
+- The same route-only export passes downstream bootstrap contract execution against its real JSON response without an invented empty-body assertion.
 - REST API fallback reads live resources, methods, and models and synthesizes partial OpenAPI 3.0 YAML when native export hits a known API Gateway export limitation.
 - HTTP API exports OpenAPI 3.0 YAML.
 - WebSocket API resolves as API Gateway v2 and writes partial OpenAPI 3.0 YAML synthesized from live route metadata, request models, component schemas, integration metadata, authorizers when present, and route responses.


### PR DESCRIPTION
## Summary

API Gateway can export valid route and status metadata without request or response schemas. Discovery previously exposed no structured way to distinguish that reduced contract coverage from a schema-rich export.

Each actual API Gateway OpenAPI export now carries a versioned schema-coverage audit in the existing JSON result, plus one actionable warning when coverage is incomplete. The exported OpenAPI is unchanged, and downstream behavior doesn't depend on the advisory metadata.

## What changed

- Count operations, response declarations, responses without content, request/response media without schemas, and default-only operations after OpenAPI normalization.
- Attach `openapiContractAudit` to `resolution-json` and applicable `services-json` entries across resolve-one, discover-many, and provider export paths.
- Omit the audit for dry runs, non-OpenAPI input, and unresolved document shapes rather than claiming guessed completeness.
- Emit `AWS_OPENAPI_CONTRACT_INCOMPLETE` with missing-coverage counts and guidance to define API Gateway models or enrich OpenAPI before body-schema checks become strict CI gates.
- Document the audit contract, its live evidence requirements, and its distinction from `derived-openapi-completeness`.

## Safety

- The audit makes no network calls, mutates no customer specification, and isn't consumed by bootstrap at runtime.
- HEAD and `1xx`, `204`, `205`, and `304` responses aren't counted as missing body content.
- Non-API-Gateway providers don't receive guessed audit metadata.

## Validation

- `npm test` - 447 tests passed across 26 files.
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `node scripts/verify-dist-artifact.mjs`
- `node validation/scripts/check-validation-fixtures.mjs`
- `node validation/scripts/validate-repo-spec-matrix.mjs`
- `node validation/scripts/validate-iac-signals.mjs`
- `node validation/scripts/validate-p3-surfaces.mjs`
