### PR TITLE
test(discovery): retain live contract audit proof

### DIFF
--- a/validation/evidence/README.md
+++ b/validation/evidence/README.md
@@ -40,7 +40,7 @@ The live validation stack is `spec-discovery-validation` in `us-east-1`. The lat
 <!-- evidence:live-resource-summary:start -->
 ## Live Resource Summary
 
-- Captured at: 2026-06-01T20:47:21.705Z
+- Captured at: 2026-07-17T23:03:35.148Z
 - Stack: spec-discovery-validation
 - Region: us-east-1
 - Account: XXXXXXXXXXXX
@@ -80,39 +80,40 @@ Raw live identifiers are stored only in `live-resource-manifest.local.json`.
 <!-- evidence:live-aws-surfaces:start -->
 ## Live AWS Surface Evidence
 
-- Captured at: 2026-06-01T20:48:13.606Z
-- Elapsed ms: 9773
+- Captured at: 2026-07-17T23:33:56.007Z
+- Elapsed ms: 10113
 - Stack: spec-discovery-validation
 - Region: us-east-1
 - Cases: 23
 - Passed: 23
 - Failed: 0
+- Route-only REST checks: 5/5 passed (export content omission, audit, warning, live JSON response, Content-Length)
 
-| Case | Runner | Source Type | Provider | Format | Derived OAS | Elapsed ms | Result |
-| --- | --- | --- | --- | --- | --- | ---: | --- |
-| api-gateway-rest | runtime | gateway-export | api-gateway | openapi-yaml | 3.0.3 full | 687 | pass |
-| api-gateway-rest-fallback | live-sdk | gateway-export | api-gateway | openapi-yaml | 3.0.3 partial | 309 | pass |
-| api-gateway-http | runtime | gateway-export | api-gateway | openapi-yaml | 3.0.3 full | 1196 | pass |
-| api-gateway-websocket | runtime | gateway-export | api-gateway | openapi-yaml | 3.0.3 partial | 1315 | pass |
-| appsync | runtime | appsync-schema | appsync | graphql-sdl | 3.1.0 partial | 560 | pass |
-| appsync-events | runtime | appsync-event-api | appsync-events | openapi-json | 3.1.0 partial | 399 | pass |
-| eventbridge-schemas | runtime | eventbridge-schema | eventbridge-schemas | openapi-json | 3.0.3 full | 724 | pass |
-| eventbridge-rule | runtime | eventbridge-surface | eventbridge | openapi-json | 3.1.0 partial | 464 | pass |
-| eventbridge-pipe | runtime | eventbridge-surface | eventbridge | openapi-json | 3.1.0 partial | 372 | pass |
-| eventbridge-api-destination | runtime | eventbridge-surface | eventbridge | openapi-json | 3.1.0 partial | 339 | pass |
-| cloudformation-embedded | runtime | cfn-embedded | cloudformation | openapi-json | 3.0.3 full | 691 | pass |
-| glue-schema | runtime | glue-schema | glue | avro | 3.1.0 partial | 772 | pass |
-| ssm-registry | runtime | ssm-registry | ssm | asyncapi-yaml | 3.1.0 partial | 591 | pass |
-| ssm-url-registry | runtime | ssm-registry | ssm | json-schema | 3.1.0 partial | 1045 | pass |
-| ssm-url-pointer | runtime | ssm-registry | ssm | openapi-json | 3.1.0 partial | 657 | pass |
-| lambda-url | runtime | lambda-url-export | lambda-url | openapi-yaml | 3.0.3 partial | 689 | pass |
-| lambda-event-source | runtime | lambda-event-source | lambda-event-source | openapi-json | 3.1.0 partial | 699 | pass |
-| verified-permissions | runtime | verified-permissions-schema | verified-permissions | openapi-json | 3.1.0 partial | 303 | pass |
-| step-functions | runtime | step-functions-asl | step-functions | openapi-json | 3.1.0 partial | 648 | pass |
-| alb-listener-rule | runtime | alb-listener-rule | alb-listener-rule | openapi-json | 3.1.0 partial | 362 | pass |
-| bedrock-action-group | runtime | bedrock-action-group | bedrock-action-group | openapi-json | 3.0.3 partial | 784 | pass |
-| sns-ssm-content | runtime | sns-contract | sns | asyncapi-yaml | 3.1.0 partial | 6982 | pass |
-| sns-webhook-sidecar | runtime | sns-contract | sns | asyncapi-yaml | 3.1.0 partial | 7189 | pass |
+| Case | Runner | Source Type | Provider | Format | Contract audit | Derived OAS | Elapsed ms | Result |
+| --- | --- | --- | --- | --- | --- | --- | ---: | --- |
+| api-gateway-rest | runtime | gateway-export | api-gateway | openapi-yaml | schema-incomplete (1 response(s) without content) | 3.0.3 full | 1130 | pass |
+| api-gateway-rest-fallback | live-sdk | gateway-export | api-gateway | openapi-yaml |  | 3.0.3 partial | 427 | pass |
+| api-gateway-http | runtime | gateway-export | api-gateway | openapi-yaml | schema-complete (0 response(s) without content) | 3.0.3 full | 1498 | pass |
+| api-gateway-websocket | runtime | gateway-export | api-gateway | openapi-yaml | schema-incomplete (1 response(s) without content) | 3.0.3 partial | 1758 | pass |
+| appsync | runtime | appsync-schema | appsync | graphql-sdl |  | 3.1.0 partial | 956 | pass |
+| appsync-events | runtime | appsync-event-api | appsync-events | openapi-json |  | 3.1.0 partial | 401 | pass |
+| eventbridge-schemas | runtime | eventbridge-schema | eventbridge-schemas | openapi-json |  | 3.0.3 full | 862 | pass |
+| eventbridge-rule | runtime | eventbridge-surface | eventbridge | openapi-json |  | 3.1.0 partial | 693 | pass |
+| eventbridge-pipe | runtime | eventbridge-surface | eventbridge | openapi-json |  | 3.1.0 partial | 492 | pass |
+| eventbridge-api-destination | runtime | eventbridge-surface | eventbridge | openapi-json |  | 3.1.0 partial | 405 | pass |
+| cloudformation-embedded | runtime | cfn-embedded | cloudformation | openapi-json |  | 3.0.3 full | 763 | pass |
+| glue-schema | runtime | glue-schema | glue | avro |  | 3.1.0 partial | 815 | pass |
+| ssm-registry | runtime | ssm-registry | ssm | asyncapi-yaml |  | 3.1.0 partial | 602 | pass |
+| ssm-url-registry | runtime | ssm-registry | ssm | json-schema |  | 3.1.0 partial | 872 | pass |
+| ssm-url-pointer | runtime | ssm-registry | ssm | openapi-json |  | 3.1.0 partial | 593 | pass |
+| lambda-url | runtime | lambda-url-export | lambda-url | openapi-yaml |  | 3.0.3 partial | 604 | pass |
+| lambda-event-source | runtime | lambda-event-source | lambda-event-source | openapi-json |  | 3.1.0 partial | 725 | pass |
+| verified-permissions | runtime | verified-permissions-schema | verified-permissions | openapi-json |  | 3.1.0 partial | 339 | pass |
+| step-functions | runtime | step-functions-asl | step-functions | openapi-json |  | 3.1.0 partial | 422 | pass |
+| alb-listener-rule | runtime | alb-listener-rule | alb-listener-rule | openapi-json |  | 3.1.0 partial | 341 | pass |
+| bedrock-action-group | runtime | bedrock-action-group | bedrock-action-group | openapi-json |  | 3.0.3 partial | 753 | pass |
+| sns-ssm-content | runtime | sns-contract | sns | asyncapi-yaml |  | 3.1.0 partial | 6714 | pass |
+| sns-webhook-sidecar | runtime | sns-contract | sns | asyncapi-yaml |  | 3.1.0 partial | 7114 | pass |
 <!-- evidence:live-aws-surfaces:end -->
 
 <!-- evidence:iac-repo-signals-matrix:start -->

--- a/validation/scripts/validate-live-aws-surfaces.mjs
+++ b/validation/scripts/validate-live-aws-surfaces.mjs
@@ -2,10 +2,12 @@
 /* global console, process */
 import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
+import { Buffer } from 'node:buffer';
 import os from 'node:os';
 import path from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import { TextDecoder } from 'node:util';
+import { parse as parseYaml } from 'yaml';
 import {
   AppSyncClient,
   GetApiCommand as GetAppSyncApiCommand,
@@ -932,7 +934,7 @@ function valueFor(result, key) {
   return result.resolution?.[key] ?? result.outputs?.[key] ?? result.outputs?.[outputKey] ?? '';
 }
 
-async function inspectGeneratedArtifacts(workspace, result, testCase) {
+async function inspectGeneratedArtifacts(workspace, result, testCase, warnings = []) {
   const checks = [];
   if (testCase.specMarkers?.length) {
     const specPath = result.resolution?.specPath;
@@ -996,6 +998,44 @@ async function inspectGeneratedArtifacts(workspace, result, testCase) {
     }
     checks.push({ name: `metadata contractOrigin ${testCase.metadataOrigin}`, passed: origin === testCase.metadataOrigin });
   }
+  if (testCase.contractAudit) {
+    const audit = result.resolution?.openapiContractAudit;
+    const specPath = result.resolution?.specPath;
+    const content = specPath ? await readFile(path.join(workspace, specPath), 'utf8').catch(() => '') : '';
+    let operation;
+    try {
+      operation = parseYaml(content)?.paths?.[testCase.contractAudit.path]?.[testCase.contractAudit.method];
+    } catch {
+      operation = undefined;
+    }
+    const responseDeclarations = operation?.responses && typeof operation.responses === 'object'
+      ? Object.values(operation.responses)
+      : [];
+    const auditWarnings = warnings.filter((message) => message.startsWith('AWS_OPENAPI_CONTRACT_INCOMPLETE:'));
+    checks.push({
+      name: 'contract audit reports route-only schema coverage',
+      passed:
+        audit?.schemaVersion === 1 &&
+        audit?.status === 'schema-incomplete' &&
+        audit?.responsesWithoutContent >= 1
+    });
+    checks.push({
+      name: `${testCase.contractAudit.method.toUpperCase()} ${testCase.contractAudit.path} response omits or has empty content`,
+      passed:
+        responseDeclarations.length > 0 &&
+        responseDeclarations.some((response) => {
+          if (!response || typeof response !== 'object') return false;
+          if (!Object.hasOwn(response, 'content')) return true;
+          return response.content && typeof response.content === 'object'
+            ? Object.keys(response.content).length === 0
+            : response.content == null;
+        })
+    });
+    checks.push({
+      name: 'contract audit warning emitted exactly once',
+      passed: auditWarnings.length === 1
+    });
+  }
   return checks;
 }
 
@@ -1003,6 +1043,14 @@ async function runRuntimeGatewayCase(testCase) {
   const caseStartedAt = Date.now();
   const workspace = await mkdtemp(path.join(os.tmpdir(), `spec-discovery-live-${testCase.name}-`));
   try {
+    const warnings = [];
+    const reporter = {
+      ...quietCore,
+      warning(message) {
+        warnings.push(message);
+        quietCore.warning(message);
+      }
+    };
     const inputs = resolveInputs({
       INPUT_AWS_REGION: region,
       INPUT_REPO_ROOT: workspace,
@@ -1013,12 +1061,33 @@ async function runRuntimeGatewayCase(testCase) {
       INPUT_MAX_ATTEMPTS: '2'
     });
     const result = await execute(inputs, {
-      core: quietCore,
+      core: reporter,
       aws: new TargetedApiGatewayClient(region),
       writeSpecFile: defaultWriteSpecFile,
       providerRegistry: emptyProviderRegistry
     });
-    const artifactChecks = await inspectGeneratedArtifacts(workspace, result, testCase);
+    const artifactChecks = await inspectGeneratedArtifacts(workspace, result, testCase, warnings);
+    if (testCase.contractAudit?.livePath) {
+      const liveResponse = await globalThis.fetch(
+        `https://${testCase.gatewayId}.execute-api.${region}.amazonaws.com/${testCase.contractAudit.stage}${testCase.contractAudit.livePath}`
+      );
+      const liveBody = await liveResponse.text();
+      let liveJson;
+      try {
+        liveJson = JSON.parse(liveBody);
+      } catch {
+        liveJson = undefined;
+      }
+      const contentLength = liveResponse.headers.get('content-length');
+      artifactChecks.push({
+        name: 'live route returns HTTP 200 JSON status ok',
+        passed: liveResponse.status === 200 && liveJson?.status === 'ok'
+      });
+      artifactChecks.push({
+        name: 'live route Content-Length matches JSON response bytes',
+        passed: contentLength === null || Number(contentLength) === Buffer.byteLength(liveBody)
+      });
+    }
     return {
       name: testCase.name,
       passed: assertExpectation(testCase, result) && artifactChecks.every((check) => check.passed),
@@ -1134,6 +1203,7 @@ const gatewayCases = [
     name: 'api-gateway-rest',
     gatewayId: outputs.RestApiId,
     expect: { status: 'resolved', sourceType: 'gateway-export', gatewayType: 'REST', specFormat: 'openapi-yaml' },
+    contractAudit: { path: '/health', method: 'get', stage: 'prod', livePath: '/health' },
     oasDerivation: true
   },
   {
@@ -1453,6 +1523,12 @@ const allCases = [
 const results = await mapWithConcurrency(allCases, 5, ({ testCase, runner }) => runner(testCase));
 
 const failed = results.filter((result) => !result.passed);
+const routeOnlyResult = results.find((result) => result.name === 'api-gateway-rest');
+const routeOnlyChecks = routeOnlyResult?.artifactChecks.filter((check) =>
+  check.name.includes('contract audit') ||
+  check.name.includes('GET /health') ||
+  check.name.includes('live route')
+) ?? [];
 await mkdir(path.dirname(evidenceJsonPath), { recursive: true });
 await writeFile(evidenceJsonPath, `${JSON.stringify({
   capturedAt: new Date().toISOString(),
@@ -1472,14 +1548,19 @@ const summary = [
   `- Cases: ${results.length}`,
   `- Passed: ${results.length - failed.length}`,
   `- Failed: ${failed.length}`,
+  `- Route-only REST checks: ${routeOnlyChecks.filter((check) => check.passed).length}/${routeOnlyChecks.length} passed (export content omission, audit, warning, live JSON response, Content-Length)`,
   '',
-  '| Case | Runner | Source Type | Provider | Format | Derived OAS | Elapsed ms | Result |',
-  '| --- | --- | --- | --- | --- | --- | ---: | --- |',
+  '| Case | Runner | Source Type | Provider | Format | Contract audit | Derived OAS | Elapsed ms | Result |',
+  '| --- | --- | --- | --- | --- | --- | --- | ---: | --- |',
   ...results.map((result) => {
+    const audit = result.resolution?.openapiContractAudit;
+    const auditSummary = audit
+      ? `${audit.status} (${audit.responsesWithoutContent} response(s) without content)`
+      : '';
     const derived = [valueFor(result, 'derivedOpenApiVersion'), valueFor(result, 'derivedOpenApiCompleteness')]
       .filter(Boolean)
       .join(' ');
-    return `| ${result.name} | ${result.runner} | ${valueFor(result, 'sourceType')} | ${valueFor(result, 'providerType')} | ${valueFor(result, 'specFormat')} | ${derived} | ${result.elapsedMs} | ${result.passed ? 'pass' : 'fail'} |`;
+    return `| ${result.name} | ${result.runner} | ${valueFor(result, 'sourceType')} | ${valueFor(result, 'providerType')} | ${valueFor(result, 'specFormat')} | ${auditSummary} | ${derived} | ${result.elapsedMs} | ${result.passed ? 'pass' : 'fail'} |`;
   })
 ].join('\n');
 


### PR DESCRIPTION
## Summary

The live AWS validator exercised API Gateway exports but didn't make the new schema-coverage contract part of its pass/fail criteria. A release could therefore lose the audit or warning while the broad surface matrix stayed green.

The REST fixture now proves the exported `/health` response has omitted or empty content, discovery reports one incomplete response, the warning appears exactly once, the live endpoint returns `{"status":"ok"}`, and its Content-Length matches the JSON bytes. The customer-safe evidence table records schema coverage separately from derived OpenAPI completeness.

## What changed

- Capture warning events per API Gateway runtime case and assert the stable warning prefix.
- Parse the actual exported OpenAPI and require the route-only response to omit usable content.
- Call the live `/health` route and require HTTP 200, JSON status `ok`, and a matching or omitted Content-Length.
- Publish the contract-audit status and a 5/5 route-only receipt in the sanitized evidence ledger.

## Validation

- `node validation/scripts/validate-live-aws-surfaces.mjs --region us-east-1` - 23/23 live AWS surfaces and 5/5 route-only contract checks passed.
- `npm test` - 447 tests passed across 26 files.
- `npm run typecheck`
- `npm run lint`
