### PR TITLE
test(discovery): prove contract-control wires against live API Gateway

### DIFF
--- a/tests/live/test-resources.yaml
+++ b/tests/live/test-resources.yaml
@@ -36,13 +36,123 @@ Resources:
                     statusCode: '200'
                     responseTemplates:
                       application/json: '{"status":"ok"}'
+          /no-content:
+            get:
+              responses:
+                '204':
+                  description: No content
+              x-amazon-apigateway-integration:
+                type: MOCK
+                requestTemplates:
+                  application/json: '{"statusCode": 204}'
+                responses:
+                  default:
+                    statusCode: '204'
+                    responseTemplates:
+                      application/json: ''
+          /no-content-with-body:
+            get:
+              responses:
+                '204':
+                  description: No content
+              x-amazon-apigateway-integration:
+                type: MOCK
+                requestTemplates:
+                  application/json: '{"statusCode": 204}'
+                responses:
+                  default:
+                    statusCode: '204'
+                    responseTemplates:
+                      application/json: '{"unexpected":true}'
+          /schema-valid:
+            get:
+              responses:
+                '200':
+                  description: Valid schema response
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        required:
+                          - status
+                        properties:
+                          status:
+                            type: string
+                        additionalProperties: false
+              x-amazon-apigateway-integration:
+                type: MOCK
+                requestTemplates:
+                  application/json: '{"statusCode": 200}'
+                responses:
+                  default:
+                    statusCode: '200'
+                    responseTemplates:
+                      application/json: '{"status":"valid"}'
+          /schema-invalid:
+            get:
+              responses:
+                '200':
+                  description: Invalid schema response
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        required:
+                          - status
+                        properties:
+                          status:
+                            type: string
+                        additionalProperties: false
+              x-amazon-apigateway-integration:
+                type: MOCK
+                requestTemplates:
+                  application/json: '{"statusCode": 200}'
+                responses:
+                  default:
+                    statusCode: '200'
+                    responseTemplates:
+                      application/json: '{"status":42}'
+          /unknown-length:
+            get:
+              responses:
+                '200':
+                  description: Unknown body with matching length
+              x-amazon-apigateway-integration:
+                type: MOCK
+                requestTemplates:
+                  application/json: '{"statusCode": 200}'
+                responses:
+                  default:
+                    statusCode: '200'
+                    responseTemplates:
+                      application/json: '{"status":"length"}'
+          /unknown-length-mismatch:
+            get:
+              responses:
+                '200':
+                  description: Unknown body with controlled mismatched length
+                  headers:
+                    Content-Length:
+                      schema:
+                        type: integer
+              x-amazon-apigateway-integration:
+                type: MOCK
+                requestTemplates:
+                  application/json: '{"statusCode": 200}'
+                responses:
+                  default:
+                    statusCode: '200'
+                    responseParameters:
+                      method.response.header.Content-Length: "'1'"
+                    responseTemplates:
+                      application/json: '{"status":"length-mismatch"}'
       Tags:
         - Key: postman:project-name
           Value: spec-discovery-test
         - Key: env
           Value: test
 
-  TestRestDeployment:
+  TestRestDeploymentContractControlsV2:
     Type: AWS::ApiGateway::Deployment
     DependsOn: TestRestApi
     Properties:
@@ -52,7 +162,7 @@ Resources:
     Type: AWS::ApiGateway::Stage
     Properties:
       RestApiId: !Ref TestRestApi
-      DeploymentId: !Ref TestRestDeployment
+      DeploymentId: !Ref TestRestDeploymentContractControlsV2
       StageName: prod
 
   # 2. HTTP API Gateway

--- a/validation/README.md
+++ b/validation/README.md
@@ -68,7 +68,7 @@ node validation/scripts/capture-live-manifest.mjs --stack-name spec-discovery-va
 node validation/scripts/validate-live-aws-surfaces.mjs
 ```
 
-API Gateway validation additionally retains an end-to-end route-only receipt: the exported response omits `content`, discovery reports `openapiContractAudit.status = schema-incomplete` with the `AWS_OPENAPI_CONTRACT_INCOMPLETE` warning, and the released bootstrap contract collection passes against the live JSON `/health` response. See `runbooks/api-gateway.md` for the exact evidence fields.
+API Gateway validation additionally retains an end-to-end route-only receipt: the exported response omits `content`, discovery reports `openapiContractAudit.status = schema-incomplete` with the `AWS_OPENAPI_CONTRACT_INCOMPLETE` warning, and the released bootstrap contract collection passes against the live JSON `/health` response. Live controls cover clean `204`, valid and invalid response schemas, matching nonzero Content-Length, and API Gateway's normalization of attempted carried-204 and mismatched-length responses. See `runbooks/api-gateway.md` for the exact evidence fields and generated-contract expectations.
 
 To create or refresh the live AWS stack:
 

--- a/validation/evidence/README.md
+++ b/validation/evidence/README.md
@@ -40,7 +40,7 @@ The live validation stack is `spec-discovery-validation` in `us-east-1`. The lat
 <!-- evidence:live-resource-summary:start -->
 ## Live Resource Summary
 
-- Captured at: 2026-07-17T23:03:35.148Z
+- Captured at: 2026-07-18T02:45:12.848Z
 - Stack: spec-discovery-validation
 - Region: us-east-1
 - Account: XXXXXXXXXXXX
@@ -80,40 +80,41 @@ Raw live identifiers are stored only in `live-resource-manifest.local.json`.
 <!-- evidence:live-aws-surfaces:start -->
 ## Live AWS Surface Evidence
 
-- Captured at: 2026-07-17T23:33:56.007Z
-- Elapsed ms: 10113
+- Captured at: 2026-07-18T02:47:25.479Z
+- Elapsed ms: 10181
 - Stack: spec-discovery-validation
 - Region: us-east-1
 - Cases: 23
 - Passed: 23
 - Failed: 0
 - Route-only REST checks: 5/5 passed (export content omission, audit, warning, live JSON response, Content-Length)
+- Contract-control wire checks: 6/6 passed (clean 204, managed-service normalization, valid/invalid schema payloads, Content-Length)
 
 | Case | Runner | Source Type | Provider | Format | Contract audit | Derived OAS | Elapsed ms | Result |
 | --- | --- | --- | --- | --- | --- | --- | ---: | --- |
-| api-gateway-rest | runtime | gateway-export | api-gateway | openapi-yaml | schema-incomplete (1 response(s) without content) | 3.0.3 full | 1130 | pass |
-| api-gateway-rest-fallback | live-sdk | gateway-export | api-gateway | openapi-yaml |  | 3.0.3 partial | 427 | pass |
-| api-gateway-http | runtime | gateway-export | api-gateway | openapi-yaml | schema-complete (0 response(s) without content) | 3.0.3 full | 1498 | pass |
-| api-gateway-websocket | runtime | gateway-export | api-gateway | openapi-yaml | schema-incomplete (1 response(s) without content) | 3.0.3 partial | 1758 | pass |
-| appsync | runtime | appsync-schema | appsync | graphql-sdl |  | 3.1.0 partial | 956 | pass |
-| appsync-events | runtime | appsync-event-api | appsync-events | openapi-json |  | 3.1.0 partial | 401 | pass |
-| eventbridge-schemas | runtime | eventbridge-schema | eventbridge-schemas | openapi-json |  | 3.0.3 full | 862 | pass |
-| eventbridge-rule | runtime | eventbridge-surface | eventbridge | openapi-json |  | 3.1.0 partial | 693 | pass |
-| eventbridge-pipe | runtime | eventbridge-surface | eventbridge | openapi-json |  | 3.1.0 partial | 492 | pass |
-| eventbridge-api-destination | runtime | eventbridge-surface | eventbridge | openapi-json |  | 3.1.0 partial | 405 | pass |
-| cloudformation-embedded | runtime | cfn-embedded | cloudformation | openapi-json |  | 3.0.3 full | 763 | pass |
-| glue-schema | runtime | glue-schema | glue | avro |  | 3.1.0 partial | 815 | pass |
-| ssm-registry | runtime | ssm-registry | ssm | asyncapi-yaml |  | 3.1.0 partial | 602 | pass |
-| ssm-url-registry | runtime | ssm-registry | ssm | json-schema |  | 3.1.0 partial | 872 | pass |
-| ssm-url-pointer | runtime | ssm-registry | ssm | openapi-json |  | 3.1.0 partial | 593 | pass |
-| lambda-url | runtime | lambda-url-export | lambda-url | openapi-yaml |  | 3.0.3 partial | 604 | pass |
-| lambda-event-source | runtime | lambda-event-source | lambda-event-source | openapi-json |  | 3.1.0 partial | 725 | pass |
+| api-gateway-rest | runtime | gateway-export | api-gateway | openapi-yaml | schema-incomplete (3 response(s) without content) | 3.0.3 full | 966 | pass |
+| api-gateway-rest-fallback | live-sdk | gateway-export | api-gateway | openapi-yaml |  | 3.0.3 partial | 309 | pass |
+| api-gateway-http | runtime | gateway-export | api-gateway | openapi-yaml | schema-complete (0 response(s) without content) | 3.0.3 full | 1171 | pass |
+| api-gateway-websocket | runtime | gateway-export | api-gateway | openapi-yaml | schema-incomplete (1 response(s) without content) | 3.0.3 partial | 1292 | pass |
+| appsync | runtime | appsync-schema | appsync | graphql-sdl |  | 3.1.0 partial | 683 | pass |
+| appsync-events | runtime | appsync-event-api | appsync-events | openapi-json |  | 3.1.0 partial | 240 | pass |
+| eventbridge-schemas | runtime | eventbridge-schema | eventbridge-schemas | openapi-json |  | 3.0.3 full | 677 | pass |
+| eventbridge-rule | runtime | eventbridge-surface | eventbridge | openapi-json |  | 3.1.0 partial | 366 | pass |
+| eventbridge-pipe | runtime | eventbridge-surface | eventbridge | openapi-json |  | 3.1.0 partial | 408 | pass |
+| eventbridge-api-destination | runtime | eventbridge-surface | eventbridge | openapi-json |  | 3.1.0 partial | 270 | pass |
+| cloudformation-embedded | runtime | cfn-embedded | cloudformation | openapi-json |  | 3.0.3 full | 682 | pass |
+| glue-schema | runtime | glue-schema | glue | avro |  | 3.1.0 partial | 767 | pass |
+| ssm-registry | runtime | ssm-registry | ssm | asyncapi-yaml |  | 3.1.0 partial | 570 | pass |
+| ssm-url-registry | runtime | ssm-registry | ssm | json-schema |  | 3.1.0 partial | 709 | pass |
+| ssm-url-pointer | runtime | ssm-registry | ssm | openapi-json |  | 3.1.0 partial | 565 | pass |
+| lambda-url | runtime | lambda-url-export | lambda-url | openapi-yaml |  | 3.0.3 partial | 611 | pass |
+| lambda-event-source | runtime | lambda-event-source | lambda-event-source | openapi-json |  | 3.1.0 partial | 682 | pass |
 | verified-permissions | runtime | verified-permissions-schema | verified-permissions | openapi-json |  | 3.1.0 partial | 339 | pass |
-| step-functions | runtime | step-functions-asl | step-functions | openapi-json |  | 3.1.0 partial | 422 | pass |
-| alb-listener-rule | runtime | alb-listener-rule | alb-listener-rule | openapi-json |  | 3.1.0 partial | 341 | pass |
-| bedrock-action-group | runtime | bedrock-action-group | bedrock-action-group | openapi-json |  | 3.0.3 partial | 753 | pass |
-| sns-ssm-content | runtime | sns-contract | sns | asyncapi-yaml |  | 3.1.0 partial | 6714 | pass |
-| sns-webhook-sidecar | runtime | sns-contract | sns | asyncapi-yaml |  | 3.1.0 partial | 7114 | pass |
+| step-functions | runtime | step-functions-asl | step-functions | openapi-json |  | 3.1.0 partial | 426 | pass |
+| alb-listener-rule | runtime | alb-listener-rule | alb-listener-rule | openapi-json |  | 3.1.0 partial | 371 | pass |
+| bedrock-action-group | runtime | bedrock-action-group | bedrock-action-group | openapi-json |  | 3.0.3 partial | 754 | pass |
+| sns-ssm-content | runtime | sns-contract | sns | asyncapi-yaml |  | 3.1.0 partial | 7337 | pass |
+| sns-webhook-sidecar | runtime | sns-contract | sns | asyncapi-yaml |  | 3.1.0 partial | 7756 | pass |
 <!-- evidence:live-aws-surfaces:end -->
 
 <!-- evidence:iac-repo-signals-matrix:start -->

--- a/validation/fixtures/aws/live-stack.yaml
+++ b/validation/fixtures/aws/live-stack.yaml
@@ -37,11 +37,121 @@ Resources:
                     statusCode: '200'
                     responseTemplates:
                       application/json: '{"status":"ok"}'
+          /no-content:
+            get:
+              responses:
+                '204':
+                  description: No content
+              x-amazon-apigateway-integration:
+                type: MOCK
+                requestTemplates:
+                  application/json: '{"statusCode": 204}'
+                responses:
+                  default:
+                    statusCode: '204'
+                    responseTemplates:
+                      application/json: ''
+          /no-content-with-body:
+            get:
+              responses:
+                '204':
+                  description: No content
+              x-amazon-apigateway-integration:
+                type: MOCK
+                requestTemplates:
+                  application/json: '{"statusCode": 204}'
+                responses:
+                  default:
+                    statusCode: '204'
+                    responseTemplates:
+                      application/json: '{"unexpected":true}'
+          /schema-valid:
+            get:
+              responses:
+                '200':
+                  description: Valid schema response
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        required:
+                          - status
+                        properties:
+                          status:
+                            type: string
+                        additionalProperties: false
+              x-amazon-apigateway-integration:
+                type: MOCK
+                requestTemplates:
+                  application/json: '{"statusCode": 200}'
+                responses:
+                  default:
+                    statusCode: '200'
+                    responseTemplates:
+                      application/json: '{"status":"valid"}'
+          /schema-invalid:
+            get:
+              responses:
+                '200':
+                  description: Invalid schema response
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        required:
+                          - status
+                        properties:
+                          status:
+                            type: string
+                        additionalProperties: false
+              x-amazon-apigateway-integration:
+                type: MOCK
+                requestTemplates:
+                  application/json: '{"statusCode": 200}'
+                responses:
+                  default:
+                    statusCode: '200'
+                    responseTemplates:
+                      application/json: '{"status":42}'
+          /unknown-length:
+            get:
+              responses:
+                '200':
+                  description: Unknown body with matching length
+              x-amazon-apigateway-integration:
+                type: MOCK
+                requestTemplates:
+                  application/json: '{"statusCode": 200}'
+                responses:
+                  default:
+                    statusCode: '200'
+                    responseTemplates:
+                      application/json: '{"status":"length"}'
+          /unknown-length-mismatch:
+            get:
+              responses:
+                '200':
+                  description: Unknown body with controlled mismatched length
+                  headers:
+                    Content-Length:
+                      schema:
+                        type: integer
+              x-amazon-apigateway-integration:
+                type: MOCK
+                requestTemplates:
+                  application/json: '{"statusCode": 200}'
+                responses:
+                  default:
+                    statusCode: '200'
+                    responseParameters:
+                      method.response.header.Content-Length: "'1'"
+                    responseTemplates:
+                      application/json: '{"status":"length-mismatch"}'
       Tags:
         - Key: postman:project-name
           Value: spec-discovery-validation
 
-  TestRestDeployment:
+  TestRestDeploymentContractControlsV2:
     Type: AWS::ApiGateway::Deployment
     DependsOn: TestRestApi
     Properties:
@@ -51,7 +161,7 @@ Resources:
     Type: AWS::ApiGateway::Stage
     Properties:
       RestApiId: !Ref TestRestApi
-      DeploymentId: !Ref TestRestDeployment
+      DeploymentId: !Ref TestRestDeploymentContractControlsV2
       StageName: prod
 
   TestHttpApi:

--- a/validation/runbooks/api-gateway.md
+++ b/validation/runbooks/api-gateway.md
@@ -32,11 +32,17 @@ warning prefix = AWS_OPENAPI_CONTRACT_INCOMPLETE:
 
 Pass that exact exported spec to the released bootstrap CLI. Run the generated cloud contract collection against the live `/health` route and retain a receipt showing the endpoint returns `{"status":"ok"}`, the contract run exits zero, and the legal nonzero `Content-Length` assertion passes. Do not enrich the fixture with an API Gateway response model for this check; the missing model is the behavior under test.
 
+The fixture also carries `/no-content`, `/no-content-with-body`, `/schema-valid`, `/schema-invalid`, `/unknown-length`, and `/unknown-length-mismatch` controls. Run the released bootstrap contract collection against those live routes and retain assertion-level results. API Gateway normalizes two deliberately malformed integration responses: it strips a body from `204` and recalculates `Content-Length`. Record those normalizations as live boundary evidence, then use the released strict generated-script tests for the negative carried-204 and mismatched-length assertions. Do not claim that API Gateway emitted malformed wire responses when it did not.
+
+On CloudFormation updates that change the embedded REST API `Body`, API Gateway can snapshot the prior route set if a replacement deployment is created in the same update. Apply the body update first, then force a second `AWS::ApiGateway::Deployment` replacement after the resources exist. A fresh stack creation needs only one deploy.
+
 ## Expected Evidence
 
 - REST API exports OpenAPI 3.0 YAML.
 - Route-only REST exports carry a schema-version-1 `schema-incomplete` audit and the actionable warning without modifying the exported OpenAPI.
 - The same route-only export passes downstream bootstrap contract execution against its real JSON response without an invented empty-body assertion.
+- Live schema-valid and matching-length controls pass their generated assertions; the live schema-invalid control fails the generated OpenAPI schema assertion.
+- The clean `204` carries zero body bytes. API Gateway strips the attempted `204` payload and rewrites the attempted wrong `Content-Length`; strict generated-script tests retain those negative controls.
 - REST API fallback reads live resources, methods, and models and synthesizes partial OpenAPI 3.0 YAML when native export hits a known API Gateway export limitation.
 - HTTP API exports OpenAPI 3.0 YAML.
 - WebSocket API resolves as API Gateway v2 and writes partial OpenAPI 3.0 YAML synthesized from live route metadata, request models, component schemas, integration metadata, authorizers when present, and route responses.

--- a/validation/scripts/validate-live-aws-surfaces.mjs
+++ b/validation/scripts/validate-live-aws-surfaces.mjs
@@ -1088,6 +1088,73 @@ async function runRuntimeGatewayCase(testCase) {
         passed: contentLength === null || Number(contentLength) === Buffer.byteLength(liveBody)
       });
     }
+    if (testCase.contractAudit?.liveControls) {
+      const controls = await Promise.all([
+        '/no-content',
+        '/no-content-with-body',
+        '/schema-valid',
+        '/schema-invalid',
+        '/unknown-length',
+        '/unknown-length-mismatch'
+      ].map(async (controlPath) => {
+        const response = await globalThis.fetch(
+          `https://${testCase.gatewayId}.execute-api.${region}.amazonaws.com/${testCase.contractAudit.stage}${controlPath}`
+        );
+        const body = await response.text();
+        let json;
+        try {
+          json = JSON.parse(body);
+        } catch {
+          json = undefined;
+        }
+        return {
+          path: controlPath,
+          status: response.status,
+          bodyBytes: Buffer.byteLength(body),
+          contentLength: response.headers.get('content-length'),
+          json
+        };
+      }));
+      const byPath = new Map(controls.map((control) => [control.path, control]));
+      const lengthMatches = (control) =>
+        control?.contentLength === null || Number(control.contentLength) === control.bodyBytes;
+      artifactChecks.push(
+        {
+          name: 'live control clean 204 carries zero body bytes',
+          passed: byPath.get('/no-content')?.status === 204 && byPath.get('/no-content')?.bodyBytes === 0
+        },
+        {
+          name: 'live control API Gateway strips attempted 204 response body',
+          passed:
+            byPath.get('/no-content-with-body')?.status === 204 &&
+            byPath.get('/no-content-with-body')?.bodyBytes === 0
+        },
+        {
+          name: 'live control schema-valid route returns declared string shape',
+          passed:
+            byPath.get('/schema-valid')?.status === 200 &&
+            typeof byPath.get('/schema-valid')?.json?.status === 'string'
+        },
+        {
+          name: 'live control schema-invalid route returns controlled invalid shape',
+          passed:
+            byPath.get('/schema-invalid')?.status === 200 &&
+            typeof byPath.get('/schema-invalid')?.json?.status === 'number'
+        },
+        {
+          name: 'live control unknown body has matching nonzero Content-Length',
+          passed:
+            byPath.get('/unknown-length')?.bodyBytes > 0 &&
+            lengthMatches(byPath.get('/unknown-length'))
+        },
+        {
+          name: 'live control API Gateway rewrites attempted mismatched Content-Length',
+          passed:
+            byPath.get('/unknown-length-mismatch')?.bodyBytes > 0 &&
+            lengthMatches(byPath.get('/unknown-length-mismatch'))
+        }
+      );
+    }
     return {
       name: testCase.name,
       passed: assertExpectation(testCase, result) && artifactChecks.every((check) => check.passed),
@@ -1203,7 +1270,7 @@ const gatewayCases = [
     name: 'api-gateway-rest',
     gatewayId: outputs.RestApiId,
     expect: { status: 'resolved', sourceType: 'gateway-export', gatewayType: 'REST', specFormat: 'openapi-yaml' },
-    contractAudit: { path: '/health', method: 'get', stage: 'prod', livePath: '/health' },
+    contractAudit: { path: '/health', method: 'get', stage: 'prod', livePath: '/health', liveControls: true },
     oasDerivation: true
   },
   {
@@ -1529,6 +1596,9 @@ const routeOnlyChecks = routeOnlyResult?.artifactChecks.filter((check) =>
   check.name.includes('GET /health') ||
   check.name.includes('live route')
 ) ?? [];
+const liveControlChecks = routeOnlyResult?.artifactChecks.filter((check) =>
+  check.name.startsWith('live control ')
+) ?? [];
 await mkdir(path.dirname(evidenceJsonPath), { recursive: true });
 await writeFile(evidenceJsonPath, `${JSON.stringify({
   capturedAt: new Date().toISOString(),
@@ -1549,6 +1619,7 @@ const summary = [
   `- Passed: ${results.length - failed.length}`,
   `- Failed: ${failed.length}`,
   `- Route-only REST checks: ${routeOnlyChecks.filter((check) => check.passed).length}/${routeOnlyChecks.length} passed (export content omission, audit, warning, live JSON response, Content-Length)`,
+  `- Contract-control wire checks: ${liveControlChecks.filter((check) => check.passed).length}/${liveControlChecks.length} passed (clean 204, managed-service normalization, valid/invalid schema payloads, Content-Length)`,
   '',
   '| Case | Runner | Source Type | Provider | Format | Contract audit | Derived OAS | Elapsed ms | Result |',
   '| --- | --- | --- | --- | --- | --- | --- | ---: | --- |',


### PR DESCRIPTION
Extends the live validation stack with six MOCK contract-control routes and asserts the measured wire behavior in validate-live-aws-surfaces.mjs:

- clean 204 carries zero body bytes
- attempted 204 body is stripped by API Gateway (measured normalization)
- schema-valid route returns the declared shape; schema-invalid route returns a controlled invalid shape
- unknown-body route has matching nonzero Content-Length
- attempted mismatched Content-Length is rewritten by API Gateway (measured normalization)

The two normalized negatives document why malformed wires cannot be emitted from behind API Gateway; strict released-script unit tests retain that coverage. Runbook + fixtures updated; live run: 23 cases, status ok.

Evidence: validation/evidence/live-aws-surfaces.local.json (local), all 10 api-gateway-rest artifact checks passing.