### PR TITLE
Harden nested contract inputs for v3 release

### DIFF
--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -162222,11 +162222,30 @@ function parseMajorVersion(version) {
   if (!match) return void 0;
   return Number(match[1]);
 }
+function resolveCdkDirectoryWithinRoot(repoRoot, directory, errors) {
+  const normalized = toPosix(import_node_path10.default.posix.normalize((directory || ".").trim()));
+  const relativeDir = normalized === "." ? "" : normalized.replace(/\/+$/, "");
+  const checkPath = relativeDir || ".";
+  try {
+    resolvePathWithinRoot(repoRoot, checkPath, "cdk-directory");
+  } catch (error2) {
+    const message = error2 instanceof Error ? error2.message : String(error2);
+    errors.push({
+      code: "path-escape",
+      path: toPosix(checkPath),
+      message
+    });
+    return void 0;
+  }
+  return relativeDir;
+}
 async function resolveAssemblyDirectory(repoRoot, assemblyDir, budget, errors, options) {
+  const relativeDir = resolveCdkDirectoryWithinRoot(repoRoot, assemblyDir, errors);
+  if (relativeDir === void 0) return [];
   const visited = options.visitedAssemblies ?? /* @__PURE__ */ new Set();
-  const relativeDir = toPosix(assemblyDir);
-  if (visited.has(relativeDir)) return [];
-  visited.add(relativeDir);
+  const visitKey = relativeDir || ".";
+  if (visited.has(visitKey)) return [];
+  visited.add(visitKey);
   const manifestRelative = relativeDir === "." || relativeDir === "" ? "manifest.json" : `${relativeDir}/manifest.json`;
   const manifestFile = await readIacFile(repoRoot, manifestRelative, budget, errors, {
     fieldName: "cdk-manifest",
@@ -162328,7 +162347,10 @@ async function resolveAssemblyDirectory(repoRoot, assemblyDir, budget, errors, o
         });
         continue;
       }
-      const nestedRelative = relativeDir ? toPosix(import_node_path10.default.posix.join(relativeDir, nestedDir)) : toPosix(nestedDir);
+      const nestedRaw = toPosix(nestedDir.trim());
+      const nestedJoined = relativeDir ? import_node_path10.default.posix.normalize(import_node_path10.default.posix.join(relativeDir, nestedRaw)) : import_node_path10.default.posix.normalize(nestedRaw);
+      const nestedRelative = resolveCdkDirectoryWithinRoot(repoRoot, nestedJoined, errors);
+      if (nestedRelative === void 0) continue;
       const nested = await resolveAssemblyDirectory(repoRoot, nestedRelative, budget, errors, {
         ...options,
         visitedAssemblies: visited
@@ -162362,7 +162384,9 @@ async function resolveAssemblyDirectory(repoRoot, assemblyDir, budget, errors, o
   return candidates;
 }
 async function resolveTemplateGlob(repoRoot, directory, budget, errors, options) {
-  const absolute = import_node_path10.default.resolve(repoRoot, directory);
+  const relativeDir = resolveCdkDirectoryWithinRoot(repoRoot, directory, errors);
+  if (relativeDir === void 0) return [];
+  const absolute = import_node_path10.default.resolve(repoRoot, relativeDir || ".");
   try {
     const info = await (0, import_promises7.lstat)(absolute);
     if (info.isSymbolicLink() || !info.isDirectory()) return [];
@@ -162378,7 +162402,7 @@ async function resolveTemplateGlob(repoRoot, directory, budget, errors, options)
     boundsExceededRecorded = true;
     errors.push({
       code: "bounds-exceeded",
-      path: toPosix(directory),
+      path: toPosix(relativeDir || "."),
       message: `CDK template discovery exceeded inspected-entry bound derived from maxFiles=${budget.maxFiles}`
     });
   };
@@ -162397,7 +162421,7 @@ async function resolveTemplateGlob(repoRoot, directory, budget, errors, options)
     inspectedEntries += 1;
     const entry = dirent.name;
     if (!entry.endsWith(".template.json")) continue;
-    const relative = toPosix(import_node_path10.default.posix.join(directory, entry));
+    const relative = toPosix(import_node_path10.default.posix.join(relativeDir || ".", entry));
     try {
       const entryInfo = await (0, import_promises7.lstat)(import_node_path10.default.resolve(repoRoot, relative));
       if (entryInfo.isSymbolicLink() || !entryInfo.isFile()) continue;
@@ -162409,7 +162433,7 @@ async function resolveTemplateGlob(repoRoot, directory, budget, errors, options)
   matching.sort((a5, b5) => a5.localeCompare(b5));
   const candidates = [];
   for (const entry of matching) {
-    const relative = toPosix(import_node_path10.default.posix.join(directory, entry));
+    const relative = toPosix(import_node_path10.default.posix.join(relativeDir || ".", entry));
     const stackCandidates = await resolveCloudFormationTemplate(
       repoRoot,
       relative,
@@ -163799,38 +163823,112 @@ async function readSmithyModelFile(state2, absolute, relative) {
     });
     return;
   }
-  let content;
-  try {
-    content = await (0, import_promises11.readFile)(absolute, "utf8");
-  } catch (error2) {
-    state2.errors.push({
-      code: "unreadable",
-      path: relative,
-      message: `Failed to read Smithy model: ${error2 instanceof Error ? error2.message : String(error2)}`
-    });
+  const bounded = await readBoundedSmithyModelBytes(absolute, relative, state2);
+  if (!bounded.ok) {
+    state2.errors.push(bounded.error);
     return;
   }
-  const bytes = Buffer.byteLength(content, "utf8");
-  if (bytes > state2.maxFileBytes) {
-    state2.errors.push({
-      code: "bounds-exceeded",
-      path: relative,
-      message: `Smithy model exceeds maxFileBytes=${state2.maxFileBytes}`
-    });
-    return;
-  }
-  if (state2.cumulativeBytes + bytes > state2.maxCumulativeBytes) {
-    state2.errors.push({
-      code: "bounds-exceeded",
-      path: relative,
-      message: `Smithy closure exceeds maxCumulativeBytes=${state2.maxCumulativeBytes}`
-    });
-    return;
-  }
-  state2.cumulativeBytes += bytes;
+  state2.cumulativeBytes += bounded.bytes;
   state2.filesRead += 1;
-  state2.contents.set(relative, content);
+  state2.contents.set(relative, bounded.content);
   state2.memberPaths.push(relative);
+}
+async function readBoundedSmithyModelBytes(absolute, relative, state2) {
+  let handle;
+  try {
+    handle = await (0, import_promises11.open)(absolute, "r");
+  } catch (error2) {
+    return {
+      ok: false,
+      error: {
+        code: "unreadable",
+        path: relative,
+        message: `Failed to read Smithy model: ${error2 instanceof Error ? error2.message : String(error2)}`
+      }
+    };
+  }
+  try {
+    let info;
+    try {
+      info = await handle.stat();
+    } catch (error2) {
+      return {
+        ok: false,
+        error: {
+          code: "unreadable",
+          path: relative,
+          message: `Failed to read Smithy model: ${error2 instanceof Error ? error2.message : String(error2)}`
+        }
+      };
+    }
+    if (!info.isFile()) {
+      return {
+        ok: false,
+        error: {
+          code: "unreadable",
+          path: relative,
+          message: `Smithy model is not a regular file: ${relative}`
+        }
+      };
+    }
+    if (info.size > state2.maxFileBytes) {
+      return {
+        ok: false,
+        error: {
+          code: "bounds-exceeded",
+          path: relative,
+          message: `Smithy model exceeds maxFileBytes=${state2.maxFileBytes}`
+        }
+      };
+    }
+    if (state2.cumulativeBytes + info.size > state2.maxCumulativeBytes) {
+      return {
+        ok: false,
+        error: {
+          code: "bounds-exceeded",
+          path: relative,
+          message: `Smithy closure exceeds maxCumulativeBytes=${state2.maxCumulativeBytes}`
+        }
+      };
+    }
+    let content;
+    try {
+      content = await handle.readFile("utf8");
+    } catch (error2) {
+      return {
+        ok: false,
+        error: {
+          code: "unreadable",
+          path: relative,
+          message: `Failed to read Smithy model: ${error2 instanceof Error ? error2.message : String(error2)}`
+        }
+      };
+    }
+    const bytes = Buffer.byteLength(content, "utf8");
+    if (bytes > state2.maxFileBytes) {
+      return {
+        ok: false,
+        error: {
+          code: "bounds-exceeded",
+          path: relative,
+          message: `Smithy model exceeds maxFileBytes=${state2.maxFileBytes}`
+        }
+      };
+    }
+    if (state2.cumulativeBytes + bytes > state2.maxCumulativeBytes) {
+      return {
+        ok: false,
+        error: {
+          code: "bounds-exceeded",
+          path: relative,
+          message: `Smithy closure exceeds maxCumulativeBytes=${state2.maxCumulativeBytes}`
+        }
+      };
+    }
+    return { ok: true, content, bytes };
+  } finally {
+    await handle.close().catch(() => void 0);
+  }
 }
 function parseSmithyBuildJson(raw) {
   const withoutComments = raw.replace(/^\s*\/\/.*$/gm, "");

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -165204,11 +165204,30 @@ function parseMajorVersion(version) {
   if (!match) return void 0;
   return Number(match[1]);
 }
+function resolveCdkDirectoryWithinRoot(repoRoot, directory, errors) {
+  const normalized = toPosix(import_node_path10.default.posix.normalize((directory || ".").trim()));
+  const relativeDir = normalized === "." ? "" : normalized.replace(/\/+$/, "");
+  const checkPath = relativeDir || ".";
+  try {
+    resolvePathWithinRoot(repoRoot, checkPath, "cdk-directory");
+  } catch (error3) {
+    const message = error3 instanceof Error ? error3.message : String(error3);
+    errors.push({
+      code: "path-escape",
+      path: toPosix(checkPath),
+      message
+    });
+    return void 0;
+  }
+  return relativeDir;
+}
 async function resolveAssemblyDirectory(repoRoot, assemblyDir, budget, errors, options) {
+  const relativeDir = resolveCdkDirectoryWithinRoot(repoRoot, assemblyDir, errors);
+  if (relativeDir === void 0) return [];
   const visited = options.visitedAssemblies ?? /* @__PURE__ */ new Set();
-  const relativeDir = toPosix(assemblyDir);
-  if (visited.has(relativeDir)) return [];
-  visited.add(relativeDir);
+  const visitKey = relativeDir || ".";
+  if (visited.has(visitKey)) return [];
+  visited.add(visitKey);
   const manifestRelative = relativeDir === "." || relativeDir === "" ? "manifest.json" : `${relativeDir}/manifest.json`;
   const manifestFile = await readIacFile(repoRoot, manifestRelative, budget, errors, {
     fieldName: "cdk-manifest",
@@ -165310,7 +165329,10 @@ async function resolveAssemblyDirectory(repoRoot, assemblyDir, budget, errors, o
         });
         continue;
       }
-      const nestedRelative = relativeDir ? toPosix(import_node_path10.default.posix.join(relativeDir, nestedDir)) : toPosix(nestedDir);
+      const nestedRaw = toPosix(nestedDir.trim());
+      const nestedJoined = relativeDir ? import_node_path10.default.posix.normalize(import_node_path10.default.posix.join(relativeDir, nestedRaw)) : import_node_path10.default.posix.normalize(nestedRaw);
+      const nestedRelative = resolveCdkDirectoryWithinRoot(repoRoot, nestedJoined, errors);
+      if (nestedRelative === void 0) continue;
       const nested = await resolveAssemblyDirectory(repoRoot, nestedRelative, budget, errors, {
         ...options,
         visitedAssemblies: visited
@@ -165344,7 +165366,9 @@ async function resolveAssemblyDirectory(repoRoot, assemblyDir, budget, errors, o
   return candidates;
 }
 async function resolveTemplateGlob(repoRoot, directory, budget, errors, options) {
-  const absolute = import_node_path10.default.resolve(repoRoot, directory);
+  const relativeDir = resolveCdkDirectoryWithinRoot(repoRoot, directory, errors);
+  if (relativeDir === void 0) return [];
+  const absolute = import_node_path10.default.resolve(repoRoot, relativeDir || ".");
   try {
     const info2 = await (0, import_promises8.lstat)(absolute);
     if (info2.isSymbolicLink() || !info2.isDirectory()) return [];
@@ -165360,7 +165384,7 @@ async function resolveTemplateGlob(repoRoot, directory, budget, errors, options)
     boundsExceededRecorded = true;
     errors.push({
       code: "bounds-exceeded",
-      path: toPosix(directory),
+      path: toPosix(relativeDir || "."),
       message: `CDK template discovery exceeded inspected-entry bound derived from maxFiles=${budget.maxFiles}`
     });
   };
@@ -165379,7 +165403,7 @@ async function resolveTemplateGlob(repoRoot, directory, budget, errors, options)
     inspectedEntries += 1;
     const entry = dirent.name;
     if (!entry.endsWith(".template.json")) continue;
-    const relative2 = toPosix(import_node_path10.default.posix.join(directory, entry));
+    const relative2 = toPosix(import_node_path10.default.posix.join(relativeDir || ".", entry));
     try {
       const entryInfo = await (0, import_promises8.lstat)(import_node_path10.default.resolve(repoRoot, relative2));
       if (entryInfo.isSymbolicLink() || !entryInfo.isFile()) continue;
@@ -165391,7 +165415,7 @@ async function resolveTemplateGlob(repoRoot, directory, budget, errors, options)
   matching.sort((a5, b5) => a5.localeCompare(b5));
   const candidates = [];
   for (const entry of matching) {
-    const relative2 = toPosix(import_node_path10.default.posix.join(directory, entry));
+    const relative2 = toPosix(import_node_path10.default.posix.join(relativeDir || ".", entry));
     const stackCandidates = await resolveCloudFormationTemplate(
       repoRoot,
       relative2,
@@ -166781,38 +166805,112 @@ async function readSmithyModelFile(state2, absolute, relative2) {
     });
     return;
   }
-  let content;
-  try {
-    content = await (0, import_promises12.readFile)(absolute, "utf8");
-  } catch (error3) {
-    state2.errors.push({
-      code: "unreadable",
-      path: relative2,
-      message: `Failed to read Smithy model: ${error3 instanceof Error ? error3.message : String(error3)}`
-    });
+  const bounded = await readBoundedSmithyModelBytes(absolute, relative2, state2);
+  if (!bounded.ok) {
+    state2.errors.push(bounded.error);
     return;
   }
-  const bytes = Buffer.byteLength(content, "utf8");
-  if (bytes > state2.maxFileBytes) {
-    state2.errors.push({
-      code: "bounds-exceeded",
-      path: relative2,
-      message: `Smithy model exceeds maxFileBytes=${state2.maxFileBytes}`
-    });
-    return;
-  }
-  if (state2.cumulativeBytes + bytes > state2.maxCumulativeBytes) {
-    state2.errors.push({
-      code: "bounds-exceeded",
-      path: relative2,
-      message: `Smithy closure exceeds maxCumulativeBytes=${state2.maxCumulativeBytes}`
-    });
-    return;
-  }
-  state2.cumulativeBytes += bytes;
+  state2.cumulativeBytes += bounded.bytes;
   state2.filesRead += 1;
-  state2.contents.set(relative2, content);
+  state2.contents.set(relative2, bounded.content);
   state2.memberPaths.push(relative2);
+}
+async function readBoundedSmithyModelBytes(absolute, relative2, state2) {
+  let handle;
+  try {
+    handle = await (0, import_promises12.open)(absolute, "r");
+  } catch (error3) {
+    return {
+      ok: false,
+      error: {
+        code: "unreadable",
+        path: relative2,
+        message: `Failed to read Smithy model: ${error3 instanceof Error ? error3.message : String(error3)}`
+      }
+    };
+  }
+  try {
+    let info2;
+    try {
+      info2 = await handle.stat();
+    } catch (error3) {
+      return {
+        ok: false,
+        error: {
+          code: "unreadable",
+          path: relative2,
+          message: `Failed to read Smithy model: ${error3 instanceof Error ? error3.message : String(error3)}`
+        }
+      };
+    }
+    if (!info2.isFile()) {
+      return {
+        ok: false,
+        error: {
+          code: "unreadable",
+          path: relative2,
+          message: `Smithy model is not a regular file: ${relative2}`
+        }
+      };
+    }
+    if (info2.size > state2.maxFileBytes) {
+      return {
+        ok: false,
+        error: {
+          code: "bounds-exceeded",
+          path: relative2,
+          message: `Smithy model exceeds maxFileBytes=${state2.maxFileBytes}`
+        }
+      };
+    }
+    if (state2.cumulativeBytes + info2.size > state2.maxCumulativeBytes) {
+      return {
+        ok: false,
+        error: {
+          code: "bounds-exceeded",
+          path: relative2,
+          message: `Smithy closure exceeds maxCumulativeBytes=${state2.maxCumulativeBytes}`
+        }
+      };
+    }
+    let content;
+    try {
+      content = await handle.readFile("utf8");
+    } catch (error3) {
+      return {
+        ok: false,
+        error: {
+          code: "unreadable",
+          path: relative2,
+          message: `Failed to read Smithy model: ${error3 instanceof Error ? error3.message : String(error3)}`
+        }
+      };
+    }
+    const bytes = Buffer.byteLength(content, "utf8");
+    if (bytes > state2.maxFileBytes) {
+      return {
+        ok: false,
+        error: {
+          code: "bounds-exceeded",
+          path: relative2,
+          message: `Smithy model exceeds maxFileBytes=${state2.maxFileBytes}`
+        }
+      };
+    }
+    if (state2.cumulativeBytes + bytes > state2.maxCumulativeBytes) {
+      return {
+        ok: false,
+        error: {
+          code: "bounds-exceeded",
+          path: relative2,
+          message: `Smithy closure exceeds maxCumulativeBytes=${state2.maxCumulativeBytes}`
+        }
+      };
+    }
+    return { ok: true, content, bytes };
+  } finally {
+    await handle.close().catch(() => void 0);
+  }
 }
 function parseSmithyBuildJson(raw) {
   const withoutComments = raw.replace(/^\s*\/\/.*$/gm, "");

--- a/src/lib/iac/cdk.ts
+++ b/src/lib/iac/cdk.ts
@@ -2,6 +2,7 @@ import { lstat, opendir } from 'node:fs/promises';
 import path from 'node:path';
 
 import type { S3SpecClient } from '../aws/s3-client.js';
+import { resolvePathWithinRoot } from '../utils/resolve-path-within-root.js';
 import { resolveCloudFormationTemplate } from './cloudformation.js';
 import { classifyIacArtifact } from './freshness.js';
 import { readIacFile, toPosix, type IacReadBudget } from './read.js';
@@ -34,6 +35,34 @@ function parseMajorVersion(version: string | undefined): number | undefined {
   return Number(match[1]);
 }
 
+/**
+ * Lexical containment for CDK assembly / template-glob directories.
+ * Normalizes the relative path and rejects anything outside repoRoot before any
+ * lstat/opendir. Returns the normalized posix-relative directory, or undefined
+ * after recording a single path-escape error.
+ */
+function resolveCdkDirectoryWithinRoot(
+  repoRoot: string,
+  directory: string,
+  errors: IacResolutionError[]
+): string | undefined {
+  const normalized = toPosix(path.posix.normalize((directory || '.').trim()));
+  const relativeDir = normalized === '.' ? '' : normalized.replace(/\/+$/, '');
+  const checkPath = relativeDir || '.';
+  try {
+    resolvePathWithinRoot(repoRoot, checkPath, 'cdk-directory');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    errors.push({
+      code: 'path-escape',
+      path: toPosix(checkPath),
+      message
+    });
+    return undefined;
+  }
+  return relativeDir;
+}
+
 async function resolveAssemblyDirectory(
   repoRoot: string,
   assemblyDir: string,
@@ -45,10 +74,14 @@ async function resolveAssemblyDirectory(
     sourceHints?: string[];
   }
 ): Promise<IacSpecCandidate[]> {
+  // Containment before any I/O — including the missing-manifest template-glob fallback.
+  const relativeDir = resolveCdkDirectoryWithinRoot(repoRoot, assemblyDir, errors);
+  if (relativeDir === undefined) return [];
+
   const visited = options.visitedAssemblies ?? new Set<string>();
-  const relativeDir = toPosix(assemblyDir);
-  if (visited.has(relativeDir)) return [];
-  visited.add(relativeDir);
+  const visitKey = relativeDir || '.';
+  if (visited.has(visitKey)) return [];
+  visited.add(visitKey);
 
   const manifestRelative = relativeDir === '.' || relativeDir === ''
     ? 'manifest.json'
@@ -164,9 +197,14 @@ async function resolveAssemblyDirectory(
         });
         continue;
       }
-      const nestedRelative = relativeDir
-        ? toPosix(path.posix.join(relativeDir, nestedDir))
-        : toPosix(nestedDir);
+      // Normalize + validate before recursion so escaping directoryName never reaches
+      // resolveAssemblyDirectory / resolveTemplateGlob enumeration.
+      const nestedRaw = toPosix(nestedDir.trim());
+      const nestedJoined = relativeDir
+        ? path.posix.normalize(path.posix.join(relativeDir, nestedRaw))
+        : path.posix.normalize(nestedRaw);
+      const nestedRelative = resolveCdkDirectoryWithinRoot(repoRoot, nestedJoined, errors);
+      if (nestedRelative === undefined) continue;
       const nested = await resolveAssemblyDirectory(repoRoot, nestedRelative, budget, errors, {
         ...options,
         visitedAssemblies: visited
@@ -210,7 +248,11 @@ async function resolveTemplateGlob(
   errors: IacResolutionError[],
   options: { s3Client?: S3SpecClient; sourceHints?: string[] }
 ): Promise<IacSpecCandidate[]> {
-  const absolute = path.resolve(repoRoot, directory);
+  // Containment before any lstat/opendir — never enumerate outside repoRoot.
+  const relativeDir = resolveCdkDirectoryWithinRoot(repoRoot, directory, errors);
+  if (relativeDir === undefined) return [];
+
+  const absolute = path.resolve(repoRoot, relativeDir || '.');
   try {
     const info = await lstat(absolute);
     if (info.isSymbolicLink() || !info.isDirectory()) return [];
@@ -228,7 +270,7 @@ async function resolveTemplateGlob(
     boundsExceededRecorded = true;
     errors.push({
       code: 'bounds-exceeded',
-      path: toPosix(directory),
+      path: toPosix(relativeDir || '.'),
       message: `CDK template discovery exceeded inspected-entry bound derived from maxFiles=${budget.maxFiles}`
     });
   };
@@ -251,7 +293,7 @@ async function resolveTemplateGlob(
     const entry = dirent.name;
     if (!entry.endsWith('.template.json')) continue;
 
-    const relative = toPosix(path.posix.join(directory, entry));
+    const relative = toPosix(path.posix.join(relativeDir || '.', entry));
     try {
       const entryInfo = await lstat(path.resolve(repoRoot, relative));
       if (entryInfo.isSymbolicLink() || !entryInfo.isFile()) continue;
@@ -265,7 +307,7 @@ async function resolveTemplateGlob(
 
   const candidates: IacSpecCandidate[] = [];
   for (const entry of matching) {
-    const relative = toPosix(path.posix.join(directory, entry));
+    const relative = toPosix(path.posix.join(relativeDir || '.', entry));
     const stackCandidates = await resolveCloudFormationTemplate(
       repoRoot,
       relative,

--- a/src/lib/repo/smithy-project.ts
+++ b/src/lib/repo/smithy-project.ts
@@ -1,4 +1,5 @@
-import { lstat, opendir, readFile } from 'node:fs/promises';
+import { lstat, open, opendir, readFile } from 'node:fs/promises';
+import type { FileHandle } from 'node:fs/promises';
 import path from 'node:path';
 
 export type SmithyProjectErrorCode =
@@ -524,6 +525,13 @@ async function collectNestedSmithyBuild(state: ClosureState, absolute: string, r
   }
 }
 
+/**
+ * Read a .smithy model under the closure resource budget.
+ * Opens the path, fstats the opened handle, and rejects non-regular /
+ * oversized / cumulative-limit content before reading any bytes through
+ * that same handle. Re-checks actual UTF-8 byte length before acceptance.
+ * Never returns rejected content into the closure; always closes the handle.
+ */
 async function readSmithyModelFile(state: ClosureState, absolute: string, relative: string): Promise<void> {
   if (state.contents.has(relative)) {
     return;
@@ -542,40 +550,135 @@ async function readSmithyModelFile(state: ClosureState, absolute: string, relati
     return;
   }
 
-  let content: string;
-  try {
-    content = await readFile(absolute, 'utf8');
-  } catch (error) {
-    state.errors.push({
-      code: 'unreadable',
-      path: relative,
-      message: `Failed to read Smithy model: ${error instanceof Error ? error.message : String(error)}`
-    });
+  const bounded = await readBoundedSmithyModelBytes(absolute, relative, state);
+  if (!bounded.ok) {
+    state.errors.push(bounded.error);
     return;
   }
 
-  const bytes = Buffer.byteLength(content, 'utf8');
-  if (bytes > state.maxFileBytes) {
-    state.errors.push({
-      code: 'bounds-exceeded',
-      path: relative,
-      message: `Smithy model exceeds maxFileBytes=${state.maxFileBytes}`
-    });
-    return;
-  }
-  if (state.cumulativeBytes + bytes > state.maxCumulativeBytes) {
-    state.errors.push({
-      code: 'bounds-exceeded',
-      path: relative,
-      message: `Smithy closure exceeds maxCumulativeBytes=${state.maxCumulativeBytes}`
-    });
-    return;
-  }
-
-  state.cumulativeBytes += bytes;
+  state.cumulativeBytes += bounded.bytes;
   state.filesRead += 1;
-  state.contents.set(relative, content);
+  state.contents.set(relative, bounded.content);
   state.memberPaths.push(relative);
+}
+
+type BoundedSmithyModelRead =
+  | { ok: true; content: string; bytes: number }
+  | { ok: false; error: SmithyProjectError };
+
+/**
+ * Open → fstat → size/cumulative gates → readFile(handle) → re-check.
+ * Callers retain symlink/path-escape refusals via lstat before invocation;
+ * this helper still refuses non-regular opened targets and never accepts
+ * oversized content into the closure.
+ */
+async function readBoundedSmithyModelBytes(
+  absolute: string,
+  relative: string,
+  state: Pick<ClosureState, 'maxFileBytes' | 'maxCumulativeBytes' | 'cumulativeBytes'>
+): Promise<BoundedSmithyModelRead> {
+  let handle: FileHandle | undefined;
+  try {
+    handle = await open(absolute, 'r');
+  } catch (error) {
+    return {
+      ok: false,
+      error: {
+        code: 'unreadable',
+        path: relative,
+        message: `Failed to read Smithy model: ${error instanceof Error ? error.message : String(error)}`
+      }
+    };
+  }
+
+  try {
+    let info;
+    try {
+      info = await handle.stat();
+    } catch (error) {
+      return {
+        ok: false,
+        error: {
+          code: 'unreadable',
+          path: relative,
+          message: `Failed to read Smithy model: ${error instanceof Error ? error.message : String(error)}`
+        }
+      };
+    }
+
+    if (!info.isFile()) {
+      return {
+        ok: false,
+        error: {
+          code: 'unreadable',
+          path: relative,
+          message: `Smithy model is not a regular file: ${relative}`
+        }
+      };
+    }
+
+    // Reject on opened-file size before allocating/reading model bytes.
+    if (info.size > state.maxFileBytes) {
+      return {
+        ok: false,
+        error: {
+          code: 'bounds-exceeded',
+          path: relative,
+          message: `Smithy model exceeds maxFileBytes=${state.maxFileBytes}`
+        }
+      };
+    }
+    if (state.cumulativeBytes + info.size > state.maxCumulativeBytes) {
+      return {
+        ok: false,
+        error: {
+          code: 'bounds-exceeded',
+          path: relative,
+          message: `Smithy closure exceeds maxCumulativeBytes=${state.maxCumulativeBytes}`
+        }
+      };
+    }
+
+    let content: string;
+    try {
+      content = await handle.readFile('utf8');
+    } catch (error) {
+      return {
+        ok: false,
+        error: {
+          code: 'unreadable',
+          path: relative,
+          message: `Failed to read Smithy model: ${error instanceof Error ? error.message : String(error)}`
+        }
+      };
+    }
+
+    const bytes = Buffer.byteLength(content, 'utf8');
+    if (bytes > state.maxFileBytes) {
+      return {
+        ok: false,
+        error: {
+          code: 'bounds-exceeded',
+          path: relative,
+          message: `Smithy model exceeds maxFileBytes=${state.maxFileBytes}`
+        }
+      };
+    }
+    if (state.cumulativeBytes + bytes > state.maxCumulativeBytes) {
+      return {
+        ok: false,
+        error: {
+          code: 'bounds-exceeded',
+          path: relative,
+          message: `Smithy closure exceeds maxCumulativeBytes=${state.maxCumulativeBytes}`
+        }
+      };
+    }
+
+    return { ok: true, content, bytes };
+  } finally {
+    await handle.close().catch(() => undefined);
+  }
 }
 
 function parseSmithyBuildJson(raw: string): Record<string, unknown> {

--- a/tests/iac-static-resolution.test.ts
+++ b/tests/iac-static-resolution.test.ts
@@ -131,6 +131,122 @@ describe('resolveStaticIacCandidates — CDK', () => {
     expect(child?.evidence.some((e) => /nested CDK assembly/i.test(e))).toBe(true);
   });
 
+  it('rejects nested directoryName that escapes repoRoot before template-glob enumeration', async () => {
+    const parent = await mkdtemp(path.join(os.tmpdir(), 'iac-cdk-escape-parent-'));
+    tempDirs.push(parent);
+    const root = path.join(parent, 'repo');
+    const outside = path.join(parent, 'outside');
+    await mkdir(root);
+    await mkdir(outside);
+    await mkdir(path.join(root, 'cdk.out', 'assembly-Valid'), { recursive: true });
+
+    // Tempting outside artifact: no manifest, so a buggy fallback would opendir here.
+    const outsideMarker = '/escape-outside-must-not-appear';
+    await writeFile(
+      path.join(outside, 'Escape.template.json'),
+      JSON.stringify({
+        Resources: {
+          EscapeApi: {
+            Type: 'AWS::ApiGateway::RestApi',
+            Properties: {
+              Body: {
+                openapi: '3.0.3',
+                info: { title: 'Escape', version: '1.0.0' },
+                paths: {
+                  [outsideMarker]: { get: { responses: { '200': { description: 'ok' } } } }
+                }
+              }
+            }
+          }
+        }
+      }),
+      'utf8'
+    );
+
+    await writeFile(path.join(root, 'cdk.json'), JSON.stringify({ app: 'npx ts-node bin/app.ts' }), 'utf8');
+
+    const escapeDirectoryName = path.posix.relative(
+      path.posix.join(root.replace(/\\/g, '/'), 'cdk.out'),
+      outside.replace(/\\/g, '/')
+    );
+    await writeFile(
+      path.join(root, 'cdk.out', 'manifest.json'),
+      JSON.stringify({
+        version: '36.0.0',
+        artifacts: {
+          EscapeAssembly: {
+            type: 'cdk:cloud-assembly',
+            properties: { directoryName: escapeDirectoryName }
+          },
+          ValidAssembly: {
+            type: 'cdk:cloud-assembly',
+            properties: { directoryName: 'assembly-Valid' }
+          }
+        }
+      }),
+      'utf8'
+    );
+
+    await writeFile(
+      path.join(root, 'cdk.out', 'assembly-Valid', 'manifest.json'),
+      JSON.stringify({
+        version: '36.0.0',
+        artifacts: {
+          ValidStack: {
+            type: 'aws:cloudformation:stack',
+            properties: { templateFile: 'ValidStack.template.json' }
+          }
+        }
+      }),
+      'utf8'
+    );
+    await writeFile(
+      path.join(root, 'cdk.out', 'assembly-Valid', 'ValidStack.template.json'),
+      JSON.stringify({
+        Resources: {
+          ValidApi: {
+            Type: 'AWS::ApiGatewayV2::Api',
+            Properties: {
+              Name: 'valid',
+              ProtocolType: 'HTTP',
+              Body: {
+                openapi: '3.0.3',
+                info: { title: 'Valid', version: '1.0.0' },
+                paths: {
+                  '/valid-nested': { get: { responses: { '200': { description: 'ok' } } } }
+                }
+              }
+            }
+          }
+        }
+      }),
+      'utf8'
+    );
+
+    const result = await resolveStaticIacCandidates(root, {
+      enabledSources: { cloudformation: false, sam: false, terraform: false, serverless: false, cdk: true }
+    });
+
+    const pathEscapeErrors = result.errors.filter((error) => error.code === 'path-escape');
+    expect(pathEscapeErrors.length).toBeGreaterThanOrEqual(1);
+    expect(pathEscapeErrors.some((error) => /escap|repo-root|cdk-directory/i.test(error.message))).toBe(true);
+
+    // No outside-derived candidates/content and no legacy template-glob fallback acceptance.
+    expect(JSON.stringify(result)).not.toContain(outsideMarker);
+    expect(JSON.stringify(result)).not.toContain('Escape.template.json');
+    expect(
+      result.candidates.every((candidate) => {
+        const source = candidate.sourcePath ?? '';
+        return !source.includes('outside') && !source.includes('Escape.template.json');
+      })
+    ).toBe(true);
+
+    // Neighboring valid nested assembly still resolves (supported behavior preserved).
+    const valid = result.candidates.find((c) => c.logicalId === 'ValidApi' && c.kind === 'openapi-inline');
+    expect(valid?.content).toContain('/valid-nested');
+    expect(valid?.sourcePath).toContain('assembly-Valid');
+  });
+
   it('rejects unsupported manifest schema versions', async () => {
     const root = await withFixture('cdk-unsupported-version');
     const result = await resolveStaticIacCandidates(root, {

--- a/tests/repo-spec-inventory.test.ts
+++ b/tests/repo-spec-inventory.test.ts
@@ -177,6 +177,39 @@ describe('inventoryRepoSpecs', () => {
     }
   });
 
+  it('rejects oversized .smithy model via opened-file size before content acceptance', async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'pm-smithy-model-bounds-'));
+    try {
+      const marker = 'namespace example.oversized.model';
+      await writeFile(
+        path.join(tempDir, 'smithy-build.json'),
+        JSON.stringify({ version: '1.0', sources: ['model.smithy'] }),
+        'utf8'
+      );
+      await writeFile(
+        path.join(tempDir, 'model.smithy'),
+        `${marker}\n${'z'.repeat(500)}`,
+        'utf8'
+      );
+
+      const closure = await resolveSmithyProject(tempDir, 'smithy-build.json', {
+        maxFiles: 10,
+        maxFileBytes: 100,
+        maxCumulativeBytes: 10_000
+      });
+
+      expect(closure.errors.some((error) => error.code === 'bounds-exceeded')).toBe(true);
+      expect(closure.errors.some((error) => /maxFileBytes=/i.test(error.message))).toBe(true);
+      expect(closure.memberPaths).toEqual([]);
+      expect(closure.content).toBe('');
+      expect(closure.content).not.toContain(marker);
+      expect(closure.errors.every((error) => !error.message.includes(marker))).toBe(true);
+      expect(closure.errors.every((error) => !error.message.includes('z'.repeat(50)))).toBe(true);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('bounds cumulative smithy config and model bytes together', async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), 'pm-smithy-cumulative-bounds-'));
     try {

--- a/validation/evidence/README.md
+++ b/validation/evidence/README.md
@@ -59,7 +59,7 @@ Raw live identifiers are stored only in `live-resource-manifest.local.json`.
 <!-- evidence:repo-spec-matrix:start -->
 ## Repo Spec Matrix Evidence
 
-- Captured at: 2026-07-20T11:59:35.716Z
+- Captured at: 2026-07-20T12:56:54.998Z
 - Cases: 15
 - Passed: 15
 - Failed: 0
@@ -135,7 +135,7 @@ Raw live identifiers are stored only in `live-resource-manifest.local.json`.
 <!-- evidence:iac-repo-signals-matrix:start -->
 ## IaC and Repo Signal Matrix Evidence
 
-- Captured at: 2026-07-20T11:59:36.297Z
+- Captured at: 2026-07-20T12:56:55.551Z
 - Cases: 8
 - Passed: 8
 - Failed: 0
@@ -155,7 +155,7 @@ Raw live identifiers are stored only in `live-resource-manifest.local.json`.
 <!-- evidence:p3-surfaces:start -->
 ## P3 Surface Fixture Evidence
 
-- Captured at: 2026-07-20T11:59:36.793Z
+- Captured at: 2026-07-20T12:56:56.044Z
 - Cases: 9
 - Passed: 9
 - Failed: 0
@@ -177,7 +177,7 @@ Raw live identifiers are stored only in `live-resource-manifest.local.json`.
 <!-- evidence:support-ledger:start -->
 ## Support Ledger Enforcement
 
-- Captured at: 2026-07-20T11:59:33.747Z
+- Captured at: 2026-07-20T12:56:53.262Z
 - Ledger rows: 58
 - Advertised labels checked: 36
 - Required live rows: 26
@@ -218,7 +218,7 @@ Raw live identifiers are stored only in `live-resource-manifest.local.json`.
 <!-- evidence:live-required-matrix:start -->
 ## Live Required Cases (current-run gate)
 
-- Captured at: 2026-07-20T12:53:03.668Z
+- Captured at: 2026-07-20T12:56:56.380Z
 - Distinction: historical-preserved rows keep old sanitized receipts; not-executed rows still require a current live run.
 - Cases: 11
 - Current-run passed: 11
@@ -227,23 +227,23 @@ Raw live identifiers are stored only in `live-resource-manifest.local.json`.
 
 | Case | Status | Run class | Ledger IDs | Notes |
 | --- | --- | --- | --- | --- |
-| fox-tag-zero-config | passed | current-run | tag-postman-repo, tag-fox-split | current live runner built-cli |
-| fox-multi-environment-ambiguity | passed | current-run | tag-multi-environment-ambiguity | current live runner built-cli |
-| api-gateway-rest-native | passed | current-run | apigw-rest-native | current live runner runtime |
-| api-gateway-rest-fallback | passed | current-run | apigw-rest-fallback | current live runner live-sdk |
-| api-gateway-http-deployed-stage | passed | current-run | apigw-http-deployed-stage | current live runner runtime |
-| api-gateway-http-latest-configuration-divergence | passed | current-run | apigw-http-latest-configuration, stage-evidence-safe-selection | current live runner built-cli |
-| api-gateway-websocket-partial-control-plane | passed | current-run | apigw-websocket-partial | current live runner runtime |
-| appsync-merged-associations | passed | current-run | appsync-merged-associations | current live runner built-cli |
-| expected-identity-mismatch | passed | current-run | expected-identity-mismatch | current live runner built-cli |
-| provider-denial-typed | passed | current-run | provider-denial-typed | current live runner built-cli |
-| all-existing-live-supported-providers | passed | current-run | appsync-graphql, appsync-events, eventbridge-schemas, eventbridge-surfaces, cloudformation-embedded, glue-schema, ssm-registry, sns-contracts, lambda-url, lambda-event-source, bedrock-action-groups, alb-listener-rules, verified-permissions, step-functions | current live refresh of 17 provider cases |
+| fox-tag-zero-config | passed | current-run | tag-postman-repo, tag-fox-split | Committed sanitized current live receipt. |
+| fox-multi-environment-ambiguity | passed | current-run | tag-multi-environment-ambiguity | Committed sanitized current live receipt. |
+| api-gateway-rest-native | passed | current-run | apigw-rest-native | Committed sanitized current live receipt. |
+| api-gateway-rest-fallback | passed | current-run | apigw-rest-fallback | Committed sanitized current live receipt. |
+| api-gateway-http-deployed-stage | passed | current-run | apigw-http-deployed-stage | Committed sanitized current live receipt. |
+| api-gateway-http-latest-configuration-divergence | passed | current-run | apigw-http-latest-configuration, stage-evidence-safe-selection | Committed sanitized current live receipt. |
+| api-gateway-websocket-partial-control-plane | passed | current-run | apigw-websocket-partial | Committed sanitized current live receipt. |
+| appsync-merged-associations | passed | current-run | appsync-merged-associations | Committed sanitized current live receipt. |
+| expected-identity-mismatch | passed | current-run | expected-identity-mismatch | Committed sanitized current live receipt. |
+| provider-denial-typed | passed | current-run | provider-denial-typed | Committed sanitized current live receipt. |
+| all-existing-live-supported-providers | passed | current-run | appsync-graphql, appsync-events, eventbridge-schemas, eventbridge-surfaces, cloudformation-embedded, glue-schema, ssm-registry, sns-contracts, lambda-url, lambda-event-source, bedrock-action-groups, alb-listener-rules, verified-permissions, step-functions | Committed sanitized current live receipt. |
 <!-- evidence:live-required-matrix:end -->
 
 <!-- evidence:resolution-closure:start -->
 ## Resolution Closure Evidence
 
-- Captured at: 2026-07-20T11:59:34.802Z
+- Captured at: 2026-07-20T12:56:54.305Z
 - Fixture cases: 27
 - Fixture passed: 27
 - Vitest closure suites: pass

--- a/validation/evidence/README.md
+++ b/validation/evidence/README.md
@@ -45,7 +45,7 @@ The live validation stack is `spec-discovery-validation` in `us-east-1`. The lat
 <!-- evidence:live-resource-summary:start -->
 ## Live Resource Summary
 
-- Captured at: 2026-07-20T12:00:13.244Z
+- Captured at: 2026-07-20T12:33:25.096Z
 - Stack: spec-discovery-validation
 - Region: us-east-1
 - Account: XXXXXXXXXXXX
@@ -86,8 +86,8 @@ Raw live identifiers are stored only in `live-resource-manifest.local.json`.
 <!-- evidence:live-aws-surfaces:start -->
 ## Live AWS Surface Evidence
 
-- Captured at: 2026-07-20T12:20:22.789Z
-- Elapsed ms: 1209223
+- Captured at: 2026-07-20T12:53:03.666Z
+- Elapsed ms: 1178334
 - Stack: spec-discovery-validation
 - Region: us-east-1
 - Cases: 31
@@ -99,37 +99,37 @@ Raw live identifiers are stored only in `live-resource-manifest.local.json`.
 
 | Case | Runner | Source Type | Provider | Format | Contract audit | Derived OAS | Elapsed ms | Result |
 | --- | --- | --- | --- | --- | --- | --- | ---: | --- |
-| api-gateway-rest | runtime | gateway-export | api-gateway | openapi-yaml | schema-incomplete (4 response(s) without content) | 3.0.3 full | 2343 | pass |
-| api-gateway-rest-modeled-route | runtime | gateway-export | api-gateway | openapi-yaml | schema-incomplete (4 response(s) without content) | 3.0.3 full | 1351 | pass |
-| api-gateway-rest-fallback | live-sdk | gateway-export | api-gateway | openapi-yaml |  | 3.0.3 partial | 658 | pass |
-| api-gateway-http | runtime | gateway-export | api-gateway | openapi-yaml | schema-complete (0 response(s) without content) | 3.0.3 full | 1612 | pass |
-| api-gateway-websocket | runtime | gateway-export | api-gateway | openapi-yaml |  | 3.0.3 partial | 2169 | pass |
-| appsync | runtime | appsync-schema | appsync | graphql-sdl |  | 3.1.0 partial | 822 | pass |
-| appsync-events | runtime | appsync-event-api | appsync-events | openapi-json |  | 3.1.0 partial | 464 | pass |
-| eventbridge-schemas | runtime | eventbridge-schema | eventbridge-schemas | openapi-json |  | 3.0.3 full | 864 | pass |
-| eventbridge-rule | runtime | eventbridge-surface | eventbridge | openapi-json |  | 3.1.0 partial | 490 | pass |
-| eventbridge-pipe | runtime | eventbridge-surface | eventbridge | openapi-json |  | 3.1.0 partial | 578 | pass |
-| eventbridge-api-destination | runtime | eventbridge-surface | eventbridge | openapi-json |  | 3.1.0 partial | 431 | pass |
-| cloudformation-embedded | runtime | cfn-embedded | cloudformation | openapi-json |  | 3.0.3 full | 894 | pass |
-| glue-schema | runtime | glue-schema | glue | avro |  | 3.1.0 partial | 1046 | pass |
-| ssm-registry | runtime | ssm-registry | ssm | asyncapi-yaml |  | 3.1.0 partial | 803 | pass |
-| ssm-url-registry | runtime | ssm-registry | ssm | json-schema |  | 3.1.0 partial | 1256 | pass |
-| ssm-url-pointer | runtime | ssm-registry | ssm | openapi-json |  | 3.1.0 partial | 721 | pass |
-| lambda-url | runtime | lambda-url-export | lambda-url | openapi-yaml |  | 3.0.3 partial | 698 | pass |
-| lambda-event-source | runtime | lambda-event-source | lambda-event-source | openapi-json |  | 3.1.0 partial | 796 | pass |
-| verified-permissions | runtime | verified-permissions-schema | verified-permissions | openapi-json |  | 3.1.0 partial | 654 | pass |
-| step-functions | runtime | step-functions-asl | step-functions | openapi-json |  | 3.1.0 partial | 607 | pass |
-| alb-listener-rule | runtime | alb-listener-rule | alb-listener-rule | openapi-json |  | 3.1.0 partial | 552 | pass |
-| bedrock-action-group | runtime | bedrock-action-group | bedrock-action-group | openapi-json |  | 3.0.3 partial | 872 | pass |
-| sns-ssm-content | runtime | sns-contract | sns | asyncapi-yaml |  | 3.1.0 partial | 11537 | pass |
-| sns-webhook-sidecar | runtime | sns-contract | sns | asyncapi-yaml |  | 3.1.0 partial | 12472 | pass |
-| fox-tag-zero-config | built-cli |  |  |  |  |  | 490057 | pass |
-| fox-multi-environment-ambiguity | built-cli | manual-review |  |  |  |  | 113202 | pass |
-| api-gateway-http-latest-configuration-divergence | built-cli |  |  |  |  |  | 219653 | pass |
-| built-cli-boundary-matrix | built-cli |  |  |  |  |  | 360904 | pass |
-| appsync-merged-associations | built-cli |  |  |  |  |  | 3816 | pass |
-| provider-denial-typed | built-cli | gateway-export | api-gateway | openapi-yaml | schema-incomplete (4 response(s) without content) | 3.0.3 full | 3774 | pass |
-| expected-identity-mismatch | built-cli |  |  |  |  |  | 686 | pass |
+| api-gateway-rest | runtime | gateway-export | api-gateway | openapi-yaml | schema-incomplete (4 response(s) without content) | 3.0.3 full | 2014 | pass |
+| api-gateway-rest-modeled-route | runtime | gateway-export | api-gateway | openapi-yaml | schema-incomplete (4 response(s) without content) | 3.0.3 full | 1362 | pass |
+| api-gateway-rest-fallback | live-sdk | gateway-export | api-gateway | openapi-yaml |  | 3.0.3 partial | 445 | pass |
+| api-gateway-http | runtime | gateway-export | api-gateway | openapi-yaml | schema-complete (0 response(s) without content) | 3.0.3 full | 1387 | pass |
+| api-gateway-websocket | runtime | gateway-export | api-gateway | openapi-yaml |  | 3.0.3 partial | 1784 | pass |
+| appsync | runtime | appsync-schema | appsync | graphql-sdl |  | 3.1.0 partial | 906 | pass |
+| appsync-events | runtime | appsync-event-api | appsync-events | openapi-json |  | 3.1.0 partial | 522 | pass |
+| eventbridge-schemas | runtime | eventbridge-schema | eventbridge-schemas | openapi-json |  | 3.0.3 full | 975 | pass |
+| eventbridge-rule | runtime | eventbridge-surface | eventbridge | openapi-json |  | 3.1.0 partial | 514 | pass |
+| eventbridge-pipe | runtime | eventbridge-surface | eventbridge | openapi-json |  | 3.1.0 partial | 553 | pass |
+| eventbridge-api-destination | runtime | eventbridge-surface | eventbridge | openapi-json |  | 3.1.0 partial | 331 | pass |
+| cloudformation-embedded | runtime | cfn-embedded | cloudformation | openapi-json |  | 3.0.3 full | 681 | pass |
+| glue-schema | runtime | glue-schema | glue | avro |  | 3.1.0 partial | 872 | pass |
+| ssm-registry | runtime | ssm-registry | ssm | asyncapi-yaml |  | 3.1.0 partial | 939 | pass |
+| ssm-url-registry | runtime | ssm-registry | ssm | json-schema |  | 3.1.0 partial | 1075 | pass |
+| ssm-url-pointer | runtime | ssm-registry | ssm | openapi-json |  | 3.1.0 partial | 714 | pass |
+| lambda-url | runtime | lambda-url-export | lambda-url | openapi-yaml |  | 3.0.3 partial | 820 | pass |
+| lambda-event-source | runtime | lambda-event-source | lambda-event-source | openapi-json |  | 3.1.0 partial | 839 | pass |
+| verified-permissions | runtime | verified-permissions-schema | verified-permissions | openapi-json |  | 3.1.0 partial | 430 | pass |
+| step-functions | runtime | step-functions-asl | step-functions | openapi-json |  | 3.1.0 partial | 520 | pass |
+| alb-listener-rule | runtime | alb-listener-rule | alb-listener-rule | openapi-json |  | 3.1.0 partial | 510 | pass |
+| bedrock-action-group | runtime | bedrock-action-group | bedrock-action-group | openapi-json |  | 3.0.3 partial | 885 | pass |
+| sns-ssm-content | runtime | sns-contract | sns | asyncapi-yaml |  | 3.1.0 partial | 10244 | pass |
+| sns-webhook-sidecar | runtime | sns-contract | sns | asyncapi-yaml |  | 3.1.0 partial | 10720 | pass |
+| fox-tag-zero-config | built-cli |  |  |  |  |  | 469416 | pass |
+| fox-multi-environment-ambiguity | built-cli | manual-review |  |  |  |  | 113790 | pass |
+| api-gateway-http-latest-configuration-divergence | built-cli |  |  |  |  |  | 219903 | pass |
+| built-cli-boundary-matrix | built-cli |  |  |  |  |  | 352354 | pass |
+| appsync-merged-associations | built-cli |  |  |  |  |  | 3134 | pass |
+| provider-denial-typed | built-cli | gateway-export | api-gateway | openapi-yaml | schema-incomplete (4 response(s) without content) | 3.0.3 full | 4049 | pass |
+| expected-identity-mismatch | built-cli |  |  |  |  |  | 642 | pass |
 <!-- evidence:live-aws-surfaces:end -->
 
 <!-- evidence:iac-repo-signals-matrix:start -->
@@ -218,7 +218,7 @@ Raw live identifiers are stored only in `live-resource-manifest.local.json`.
 <!-- evidence:live-required-matrix:start -->
 ## Live Required Cases (current-run gate)
 
-- Captured at: 2026-07-20T12:20:22.790Z
+- Captured at: 2026-07-20T12:53:03.668Z
 - Distinction: historical-preserved rows keep old sanitized receipts; not-executed rows still require a current live run.
 - Cases: 11
 - Current-run passed: 11
@@ -285,7 +285,7 @@ Raw live identifiers are stored only in `live-resource-manifest.local.json`.
 <!-- evidence:built-cli-live:start -->
 ## Built CLI Live Evidence
 
-- Captured at: 2026-07-20T12:20:22.789Z
+- Captured at: 2026-07-20T12:53:03.665Z
 - Built CLI cases: 7
 - Passed: 7
 - Failed: 0

--- a/validation/evidence/live-validation-summary.json
+++ b/validation/evidence/live-validation-summary.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 1,
-  "capturedAt": "2026-07-20T12:20:22.824Z",
-  "testedSourceSha": "3a57180fa1222d501c2334d1e5d78aaab386eb19",
+  "capturedAt": "2026-07-20T12:53:03.700Z",
+  "testedSourceSha": "a89783444f3926715ad1186ca3f35fd7f2b37d14",
   "distSha256": {
-    "dist/index.cjs": "f99a57a76986c8e208c17b1751af9d3e9e6263087686f36f712695dcd1b826c1",
-    "dist/cli.cjs": "c03478159beb1d694fb1f4ee8941553fd0fa167db89819517e8f568710f567e9"
+    "dist/index.cjs": "7a6e2bdb867cbb6ec2aadb0d8652325536bbab37bc6104b340b1b8156869b311",
+    "dist/cli.cjs": "50dbea203bbf53e5101754836760a1273b7c34ae4ab6725e8ea1b9edd0558cf6"
   },
   "stackAlias": "spec-discovery-validation",
   "region": "us-east-1",
@@ -21,7 +21,7 @@
       "name": "api-gateway-rest",
       "runner": "runtime",
       "passed": true,
-      "elapsedMs": 2343,
+      "elapsedMs": 2014,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -89,7 +89,7 @@
       "name": "api-gateway-rest-modeled-route",
       "runner": "runtime",
       "passed": true,
-      "elapsedMs": 1351,
+      "elapsedMs": 1362,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -149,7 +149,7 @@
       "name": "api-gateway-rest-fallback",
       "runner": "live-sdk",
       "passed": true,
-      "elapsedMs": 658,
+      "elapsedMs": 445,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -173,7 +173,7 @@
       "name": "api-gateway-http",
       "runner": "runtime",
       "passed": true,
-      "elapsedMs": 1612,
+      "elapsedMs": 1387,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -197,7 +197,7 @@
       "name": "api-gateway-websocket",
       "runner": "runtime",
       "passed": true,
-      "elapsedMs": 2169,
+      "elapsedMs": 1784,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -285,7 +285,7 @@
       "name": "appsync",
       "runner": "runtime",
       "passed": true,
-      "elapsedMs": 822,
+      "elapsedMs": 906,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -309,7 +309,7 @@
       "name": "appsync-events",
       "runner": "runtime",
       "passed": true,
-      "elapsedMs": 464,
+      "elapsedMs": 522,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -353,7 +353,7 @@
       "name": "eventbridge-schemas",
       "runner": "runtime",
       "passed": true,
-      "elapsedMs": 864,
+      "elapsedMs": 975,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -377,7 +377,7 @@
       "name": "eventbridge-rule",
       "runner": "runtime",
       "passed": true,
-      "elapsedMs": 490,
+      "elapsedMs": 514,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -417,7 +417,7 @@
       "name": "eventbridge-pipe",
       "runner": "runtime",
       "passed": true,
-      "elapsedMs": 578,
+      "elapsedMs": 553,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -453,7 +453,7 @@
       "name": "eventbridge-api-destination",
       "runner": "runtime",
       "passed": true,
-      "elapsedMs": 431,
+      "elapsedMs": 331,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -489,7 +489,7 @@
       "name": "cloudformation-embedded",
       "runner": "runtime",
       "passed": true,
-      "elapsedMs": 894,
+      "elapsedMs": 681,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -513,7 +513,7 @@
       "name": "glue-schema",
       "runner": "runtime",
       "passed": true,
-      "elapsedMs": 1046,
+      "elapsedMs": 872,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -537,7 +537,7 @@
       "name": "ssm-registry",
       "runner": "runtime",
       "passed": true,
-      "elapsedMs": 803,
+      "elapsedMs": 939,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -561,7 +561,7 @@
       "name": "ssm-url-registry",
       "runner": "runtime",
       "passed": true,
-      "elapsedMs": 1256,
+      "elapsedMs": 1075,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -585,7 +585,7 @@
       "name": "ssm-url-pointer",
       "runner": "runtime",
       "passed": true,
-      "elapsedMs": 721,
+      "elapsedMs": 714,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -621,7 +621,7 @@
       "name": "lambda-url",
       "runner": "runtime",
       "passed": true,
-      "elapsedMs": 698,
+      "elapsedMs": 820,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -669,7 +669,7 @@
       "name": "lambda-event-source",
       "runner": "runtime",
       "passed": true,
-      "elapsedMs": 796,
+      "elapsedMs": 839,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -709,7 +709,7 @@
       "name": "verified-permissions",
       "runner": "runtime",
       "passed": true,
-      "elapsedMs": 654,
+      "elapsedMs": 430,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -753,7 +753,7 @@
       "name": "step-functions",
       "runner": "runtime",
       "passed": true,
-      "elapsedMs": 607,
+      "elapsedMs": 520,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -793,7 +793,7 @@
       "name": "alb-listener-rule",
       "runner": "runtime",
       "passed": true,
-      "elapsedMs": 552,
+      "elapsedMs": 510,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -837,7 +837,7 @@
       "name": "bedrock-action-group",
       "runner": "runtime",
       "passed": true,
-      "elapsedMs": 872,
+      "elapsedMs": 885,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -877,7 +877,7 @@
       "name": "sns-ssm-content",
       "runner": "runtime",
       "passed": true,
-      "elapsedMs": 11537,
+      "elapsedMs": 10244,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -905,7 +905,7 @@
       "name": "sns-webhook-sidecar",
       "runner": "runtime",
       "passed": true,
-      "elapsedMs": 12472,
+      "elapsedMs": 10720,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -973,7 +973,7 @@
       "name": "fox-tag-zero-config",
       "runner": "built-cli",
       "passed": true,
-      "elapsedMs": 490057,
+      "elapsedMs": 469416,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -1093,7 +1093,7 @@
       "name": "fox-multi-environment-ambiguity",
       "runner": "built-cli",
       "passed": true,
-      "elapsedMs": 113202,
+      "elapsedMs": 113790,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -1129,7 +1129,7 @@
       "name": "api-gateway-http-latest-configuration-divergence",
       "runner": "built-cli",
       "passed": true,
-      "elapsedMs": 219653,
+      "elapsedMs": 219903,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -1189,7 +1189,7 @@
       "name": "built-cli-boundary-matrix",
       "runner": "built-cli",
       "passed": true,
-      "elapsedMs": 360904,
+      "elapsedMs": 352354,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -1265,7 +1265,7 @@
       "name": "appsync-merged-associations",
       "runner": "built-cli",
       "passed": true,
-      "elapsedMs": 3816,
+      "elapsedMs": 3134,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -1301,7 +1301,7 @@
       "name": "provider-denial-typed",
       "runner": "built-cli",
       "passed": true,
-      "elapsedMs": 3774,
+      "elapsedMs": 4049,
       "artifactChecks": [
         {
           "name": "check-1",
@@ -1341,7 +1341,7 @@
       "name": "expected-identity-mismatch",
       "runner": "built-cli",
       "passed": true,
-      "elapsedMs": 686,
+      "elapsedMs": 642,
       "artifactChecks": [
         {
           "name": "check-1",


### PR DESCRIPTION
## Summary

The v3 resolver needs to reject oversized Smithy models before allocating their contents and keep nested CDK assembly fallback scans inside the checked-out repository. This closes those final local-input boundaries and binds the release evidence to the resulting bundle.

## What changed

- Check Smithy model size before reading and preserve bounded project traversal.
- Validate nested CDK assembly and fallback directories before filesystem enumeration.
- Cover oversized Smithy inputs, escaping nested assemblies, and valid bounded projects with regression tests.
- Refresh sanitized live evidence for the exact built bundle.

## Safety

The resolver still performs static inspection only. It does not execute Smithy, CDK, Terraform, Serverless, or repository build code. Escaping paths fail closed.

## Validation

- `npm test` - 713 tests passed
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run validate:offline` - 28 closure cases and all support matrices passed
- `npm run verify:dist:assert`
- Live AWS validation - 31/31 cases passed, including all 11 required boundary cases
