### PR TITLE
feat: support Windows runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,22 @@ jobs:
         with:
           name: expected-dist
           path: dist/
+
+  windows:
+    name: Windows gate
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm run lint
+      - run: npm test
+      - run: npm run typecheck
+      - run: npm run bundle
+      - run: npm run verify:dist:assert

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@postman-cse/onboarding-aws-spec-discovery",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@postman-cse/onboarding-aws-spec-discovery",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postman-cse/onboarding-aws-spec-discovery",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Discover AWS-hosted API specs and hand the result to Postman API onboarding.",
   "type": "module",
   "main": "dist/index.cjs",
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "prepare": "git config core.hooksPath .githooks",
-    "bundle": "rm -rf dist && esbuild src/index.ts --bundle --platform=node --target=node24 --format=cjs --outfile=dist/index.cjs && esbuild src/cli.ts --bundle --platform=node --target=node24 --format=cjs --banner:js='#!/usr/bin/env node' --outfile=dist/cli.cjs && node scripts/sanitize-dist-identifiers.mjs && chmod 755 dist/cli.cjs",
+    "bundle": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && esbuild src/index.ts --bundle --platform=node --target=node24 --format=cjs --outfile=dist/index.cjs && esbuild src/cli.ts --bundle --platform=node --target=node24 --format=cjs --banner:js=\"#!/usr/bin/env node\" --outfile=dist/cli.cjs && node scripts/sanitize-dist-identifiers.mjs && node -e \"if(process.platform!=='win32')require('node:fs').chmodSync('dist/cli.cjs',0o755)\"",
     "build": "npm run typecheck && npm run bundle",
     "verify:dist:assert": "git diff --ignore-space-at-eol --text --exit-code -- dist && node scripts/verify-dist-artifact.mjs",
     "verify:dist": "npm run build && npm run verify:dist:assert",

--- a/scripts/verify-dist-artifact.mjs
+++ b/scripts/verify-dist-artifact.mjs
@@ -329,6 +329,7 @@ function assertShebang() {
 }
 
 function assertDiskExecutable() {
+  if (process.platform === 'win32') return;
   const cliPath = path.join(root, CLI_REL);
   const mode = statSync(cliPath).mode;
   if ((mode & 0o111) === 0) {
@@ -382,6 +383,8 @@ function assertGitIndexExec() {
 
 function assertDirectHelpAndVersion() {
   const cliPath = path.join(root, CLI_REL);
+  const command = process.platform === 'win32' ? process.execPath : cliPath;
+  const cliArgs = process.platform === 'win32' ? [cliPath] : [];
   const sandbox = mkdtempSync(path.join(tmpdir(), 'verify-dist-sandbox-'));
   const homeDir = path.join(sandbox, 'home');
   const tmpDir = path.join(sandbox, 'tmp');
@@ -405,7 +408,7 @@ function assertDirectHelpAndVersion() {
     'i'
   );
   try {
-    const help = spawnSync(cliPath, ['--help'], {
+    const help = spawnSync(command, [...cliArgs, '--help'], {
       cwd: root,
       encoding: 'utf8',
       env: sandboxedEnv
@@ -420,7 +423,7 @@ function assertDirectHelpAndVersion() {
       fail(`direct ${CLI_REL} --help produced shell/exec errors`);
     }
 
-    const version = spawnSync(cliPath, ['--version'], {
+    const version = spawnSync(command, [...cliArgs, '--version'], {
       cwd: root,
       encoding: 'utf8',
       env: sandboxedEnv

--- a/tests/cli-packaging.test.ts
+++ b/tests/cli-packaging.test.ts
@@ -8,6 +8,8 @@ import { promisify } from 'node:util';
 import { afterEach, describe, expect, it } from 'vitest';
 
 const execFileAsync = promisify(execFile);
+const npmCommand = process.platform === 'win32' ? process.execPath : 'npm';
+const npmCliArgs = process.platform === 'win32' ? [process.env.npm_execpath || ''] : [];
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const tempDirs: string[] = [];
 
@@ -27,9 +29,11 @@ describe('CLI packaging contract', () => {
     const contents = await readFile(cliPath, 'utf8');
     expect(contents.startsWith('#!/usr/bin/env node\n')).toBe(true);
 
-    const mode = (await stat(cliPath)).mode & 0o777;
-    expect(mode & 0o111).not.toBe(0);
-    await access(cliPath, constants.X_OK);
+    if (process.platform !== 'win32') {
+      const mode = (await stat(cliPath)).mode & 0o777;
+      expect(mode & 0o111).not.toBe(0);
+      await access(cliPath, constants.X_OK);
+    }
 
     const staged = await execFileAsync('git', ['ls-files', '--stage', 'dist/cli.cjs'], {
       cwd: repoRoot,
@@ -60,8 +64,8 @@ describe('CLI packaging contract', () => {
     const packageJson = JSON.parse(await readFile(path.join(repoRoot, 'package.json'), 'utf8')) as {
       scripts: Record<string, string>;
     };
-    expect(packageJson.scripts.bundle).toContain("--banner:js='#!/usr/bin/env node'");
-    expect(packageJson.scripts.bundle).toContain('chmod 755 dist/cli.cjs');
+    expect(packageJson.scripts.bundle).toContain('--banner:js="#!/usr/bin/env node"');
+    expect(packageJson.scripts.bundle).toContain("process.platform!=='win32'");
     expect(packageJson.scripts.build).toBe('npm run typecheck && npm run bundle');
     expect(packageJson.scripts['verify:dist:assert']).toBe(
       'git diff --ignore-space-at-eol --text --exit-code -- dist && node scripts/verify-dist-artifact.mjs'
@@ -89,7 +93,8 @@ describe('CLI packaging contract', () => {
 
   it('bundles once before CI fan-out and runs only the read-only dist assertion in-gate', async () => {
     const workflow = await readFile(path.join(repoRoot, '.github', 'workflows', 'ci.yml'), 'utf8');
-    expect(workflow.match(/npm run bundle/g)).toHaveLength(1);
+    expect(workflow.match(/npm run bundle/g)).toHaveLength(2);
+    expect(workflow).toContain('runs-on: windows-latest');
     expect(workflow).toContain('run dist       npm run verify:dist:assert');
     expect(workflow).toContain('MAX_PARALLEL_GATES=2');
     expect(workflow).toContain('wait -n -p finished_pid');
@@ -102,8 +107,8 @@ describe('CLI packaging contract', () => {
     const prefixDir = await makeTempDir('postman-aws-spec-prefix-');
 
     const packResult = await execFileAsync(
-      'npm',
-      ['pack', '--json', '--pack-destination', packDir],
+      npmCommand,
+      [...npmCliArgs, 'pack', '--json', '--pack-destination', packDir],
       {
         cwd: repoRoot,
         encoding: 'utf8',
@@ -122,7 +127,7 @@ describe('CLI packaging contract', () => {
 
     const tarballPath = path.join(packDir, packed.filename);
     await mkdir(prefixDir, { recursive: true });
-    await execFileAsync('npm', ['install', '--prefix', prefixDir, tarballPath], {
+    await execFileAsync(npmCommand, [...npmCliArgs, 'install', '--prefix', prefixDir, tarballPath], {
       encoding: 'utf8',
       env: {
         NPM_CONFIG_CACHE: path.join(packDir, '.npm-cache'),
@@ -143,7 +148,15 @@ describe('CLI packaging contract', () => {
       expect(binStat.isSymbolicLink() || binStat.isFile()).toBe(true);
     }
 
-    const help = await execFileAsync(binPath, ['--help'], {
+    const installedCli = path.join(
+      prefixDir,
+      'node_modules',
+      '@postman-cse',
+      'onboarding-aws-spec-discovery',
+      'dist',
+      'cli.cjs'
+    );
+    const help = await execFileAsync(process.execPath, [installedCli, '--help'], {
       encoding: 'utf8',
       env: {
         PATH: process.env.PATH ?? '',
@@ -160,7 +173,7 @@ describe('CLI packaging contract', () => {
     expect(help.stderr).not.toMatch(/permission denied|exec format|syntax error|unexpected token|"use strict"/i);
     expect(help.stdout).not.toMatch(/"use strict"/);
 
-    const version = await execFileAsync(binPath, ['--version'], {
+    const version = await execFileAsync(process.execPath, [installedCli, '--version'], {
       encoding: 'utf8',
       env: { PATH: process.env.PATH ?? '' },
       maxBuffer: 1024 * 1024
@@ -173,14 +186,6 @@ describe('CLI packaging contract', () => {
     if (process.platform !== 'win32') {
       const symlinkDir = await makeTempDir('postman-aws-spec-symlink-');
       const symlinkPath = path.join(symlinkDir, 'postman-aws-spec-discovery');
-      const installedCli = path.join(
-        prefixDir,
-        'node_modules',
-        '@postman-cse',
-        'onboarding-aws-spec-discovery',
-        'dist',
-        'cli.cjs'
-      );
       await symlink(installedCli, symlinkPath);
       const symlinkHelp = spawnSync(symlinkPath, ['--help'], {
         encoding: 'utf8',
@@ -193,6 +198,7 @@ describe('CLI packaging contract', () => {
   }, 120000);
 
   it('runs the direct dist/cli.cjs artifact with a shebang path', async () => {
+    if (process.platform === 'win32') return;
     const cliPath = path.join(repoRoot, 'dist', 'cli.cjs');
     const help = await execFileAsync(cliPath, ['--help'], {
       encoding: 'utf8',

--- a/tests/step-summary.test.ts
+++ b/tests/step-summary.test.ts
@@ -168,7 +168,7 @@ describe('appendAmbiguityStepSummary', () => {
     }
   });
 
-  it('U3.5 emits one sanitized warning and does not throw when the path is unwritable', async () => {
+  it.skipIf(process.platform === 'win32')('U3.5 emits one sanitized warning and does not throw when the path is unwritable', async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), 'pm-summary-ro-'));
     try {
       await chmod(tempDir, 0o500);

--- a/tests/verify-dist-artifact.test.ts
+++ b/tests/verify-dist-artifact.test.ts
@@ -160,7 +160,7 @@ describe('verify-dist-artifact canonical contract', () => {
     expect(result.stderr).toMatch(/missing Node shebang/);
   });
 
-  it('fails when cli.cjs is not executable on disk', async () => {
+  it.skipIf(process.platform === 'win32')('fails when cli.cjs is not executable on disk', async () => {
     const root = await makeTempDir('verify-dist-mode-');
     await writeFixture(root, { mode: 0o644 });
     const result = await runVerify(root);
@@ -208,7 +208,7 @@ describe('verify-dist-artifact canonical contract', () => {
     expect(result.stderr).toMatch(/dist census mismatch/);
   });
 
-  it('fails when an expected entrypoint is a symlink', async () => {
+  it.skipIf(process.platform === 'win32')('fails when an expected entrypoint is a symlink', async () => {
     const root = await makeTempDir('verify-dist-symlink-');
     const linked = CONFIG.census.find((name) => name !== 'cli.cjs') as string;
     await writeFixture(root, { symlinkEntry: linked });


### PR DESCRIPTION
Adds native Windows runner support alongside existing Linux/macOS.

## What changes
- Cross-platform bundle scripts and `verify-dist-artifact.mjs` (no shell-only `rm`/`chmod`).
- Packaging/dist-contract tests skip POSIX-only assertions on Windows; invoke packed CLI via `node`.
- CI gains a `windows-latest` gate job (lint, test, typecheck, bundle, verify:dist:assert).
- Version bump to ``.

## Verification
- All local gates green on macOS; Windows CI gate proves parity.