### PR TITLE
fix(release): verify AWS artifacts and diagnose token mints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   gate:
     runs-on: ubuntu-latest
@@ -28,8 +32,12 @@ jobs:
           cache: npm
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Install actionlint
+        run: |
+          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.11 "$RUNNER_TEMP"
+          ACTIONLINT_BIN="$RUNNER_TEMP/actionlint"
+          "$ACTIONLINT_BIN" -version
+          echo "ACTIONLINT_BIN=$ACTIONLINT_BIN" >> "$GITHUB_ENV"
       # Bundle once before fan-out so pack tests and the dist assert only read
       # dist/. Typecheck stays in the fan-out so it runs exactly once.
       - run: npm run bundle
@@ -64,6 +72,7 @@ jobs:
           run typecheck  npm run typecheck
           run test       npm test
           run dist       npm run verify:dist:assert
+          run actionlint "$ACTIONLINT_BIN"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             run commitlint npx commitlint \
               --from "${{ github.event.pull_request.base.sha }}" \
@@ -97,10 +106,42 @@ jobs:
           cache: npm
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: npm run lint
-      - run: npm test
-      - run: npm run typecheck
       - run: npm run bundle
-      - run: npm run verify:dist:assert
+      - name: Run gates
+        shell: pwsh
+        run: |
+          $maxParallelGates = 2
+          $checks = @(
+            @{ Name = 'lint'; Args = @('run', 'lint') },
+            @{ Name = 'test'; Args = @('test') },
+            @{ Name = 'typecheck'; Args = @('run', 'typecheck') },
+            @{ Name = 'dist'; Args = @('run', 'verify:dist:assert') }
+          )
+          $jobs = @()
+          $results = @{}
+          foreach ($check in $checks) {
+            while ($jobs.Count -ge $maxParallelGates) {
+              $finished = Wait-Job -Job $jobs -Any
+              $output = Receive-Job -Job $finished
+              $output | Write-Output
+              $results[$finished.Name] = if ($finished.State -eq 'Completed') { 0 } else { 1 }
+              Remove-Job -Job $finished
+              $jobs = @($jobs | Where-Object Id -ne $finished.Id)
+            }
+            $jobs += Start-Job -Name $check.Name -ScriptBlock {
+              param($npmArgs)
+              & npm @npmArgs
+              if ($LASTEXITCODE -ne 0) { throw "gate failed with exit code $LASTEXITCODE" }
+            } -ArgumentList (,$check.Args)
+          }
+          foreach ($job in $jobs) {
+            Wait-Job -Job $job | Out-Null
+            Receive-Job -Job $job | Write-Output
+            $results[$job.Name] = if ($job.State -eq 'Completed') { 0 } else { 1 }
+            Remove-Job -Job $job
+          }
+          $failed = $false
+          foreach ($check in $checks) {
+            if ($results[$check.Name] -eq 0) { Write-Output "gate:$($check.Name)=pass" } else { Write-Output "gate:$($check.Name)=fail"; $failed = $true }
+          }
+          if ($failed) { exit 1 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
       - name: Run gates
         shell: pwsh
         run: |
+          $ErrorActionPreference = 'Stop'
           $maxParallelGates = 2
           $checks = @(
             @{ Name = 'lint'; Args = @('run', 'lint') },
@@ -122,8 +123,9 @@ jobs:
           foreach ($check in $checks) {
             while ($jobs.Count -ge $maxParallelGates) {
               $finished = Wait-Job -Job $jobs -Any
-              $output = Receive-Job -Job $finished
-              $output | Write-Output
+              Write-Output "::group::$($finished.Name)"
+              Receive-Job -Job $finished -ErrorAction Continue 2>&1 | Write-Output
+              Write-Output "::endgroup::"
               $results[$finished.Name] = if ($finished.State -eq 'Completed') { 0 } else { 1 }
               Remove-Job -Job $finished
               $jobs = @($jobs | Where-Object Id -ne $finished.Id)
@@ -136,7 +138,9 @@ jobs:
           }
           foreach ($job in $jobs) {
             Wait-Job -Job $job | Out-Null
-            Receive-Job -Job $job | Write-Output
+            Write-Output "::group::$($job.Name)"
+            Receive-Job -Job $job -ErrorAction Continue 2>&1 | Write-Output
+            Write-Output "::endgroup::"
             $results[$job.Name] = if ($job.State -eq 'Completed') { 0 } else { 1 }
             Remove-Job -Job $job
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,123 +7,209 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
+
+concurrency:
+  group: release-${{ github.repository }}
+  cancel-in-progress: false
 
 jobs:
-  release:
+  classify:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
+      release_kind: ${{ steps.release_tag.outputs.release_kind }}
       npm_publish: ${{ steps.release_tag.outputs.npm_publish }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
           node-version: '24'
-          cache: npm
-          registry-url: 'https://registry.npmjs.org'
-      - uses: actions/setup-go@v7
+      - name: Classify release tag
+        id: release_tag
+        run: node scripts/classify-release.mjs
+
+  verify-package:
+    needs: classify
+    if: ${{ needs.classify.outputs.release_kind == 'immutable' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
-          go-version: '1.24'
+          node-version: '24'
+          cache: npm
       - run: npm ci
+      - name: Install actionlint
+        run: |
+          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.11 "$RUNNER_TEMP"
+          ACTIONLINT_BIN="$RUNNER_TEMP/actionlint"
+          "$ACTIONLINT_BIN" -version
+          echo "ACTIONLINT_BIN=$ACTIONLINT_BIN" >> "$GITHUB_ENV"
+      - run: npm run bundle
+      - name: Run gates
+        run: |
+          set -uo pipefail
+          declare -A pid=() result=(); declare -a names=(); MAX_PARALLEL_GATES=2
+          finish_one() { local finished_pid status n; if wait -n -p finished_pid "${pid[@]}"; then status=0; else status=$?; fi; for n in "${!pid[@]}"; do if [ "${pid[$n]}" = "$finished_pid" ]; then result[$n]=$status; unset 'pid[$n]'; return; fi; done; }
+          run() { while [ "${#pid[@]}" -ge "$MAX_PARALLEL_GATES" ]; do finish_one; done; local n=$1; shift; names+=("$n"); ( "$@" ) >"$n.log" 2>&1 & pid[$n]=$!; }
+          run lint npm run lint
+          run typecheck npm run typecheck
+          run test npm test
+          run dist npm run verify:dist:assert
+          run actionlint "$ACTIONLINT_BIN"
+          while [ "${#pid[@]}" -gt 0 ]; do finish_one; done
+          fail=0; for n in "${names[@]}"; do if [ "${result[$n]}" -eq 0 ]; then echo "gate:$n=pass"; else echo "gate:$n=fail"; fail=1; fi; done
+          for n in "${names[@]}"; do echo "::group::$n"; cat "$n.log"; echo "::endgroup::"; done
+          exit $fail
+      - name: Package release artifact
+        run: |
+          mkdir release-stage
+          npm pack --pack-destination release-stage
+          mv release-stage/*.tgz release-stage/release.tgz
+          node -e 'const fs=require("fs");const crypto=require("crypto");const p=require("./package.json");const tgz="release-stage/release.tgz";const sha256=crypto.createHash("sha256").update(fs.readFileSync(tgz)).digest("hex");fs.writeFileSync("release-stage/release-manifest.json",JSON.stringify({schema_version:1,repository:process.env.GITHUB_REPOSITORY,commit_sha:process.env.GITHUB_SHA,tag:process.env.GITHUB_REF_NAME,package_name:p.name,package_version:p.version,artifacts:[{path:"release.tgz",sha256}]},null,2))'
+          node scripts/verify-release-artifacts.mjs release-stage
+      - uses: actions/upload-artifact@v7
+        with:
+          name: release-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            release-stage/release.tgz
+            release-stage/release-manifest.json
+          if-no-files-found: error
+
+  publish:
+    needs: [classify, verify-package]
+    if: ${{ needs.classify.outputs.release_kind == 'immutable' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+      - uses: actions/download-artifact@v8
+        with:
+          name: release-${{ github.run_id }}-${{ github.run_attempt }}
+          path: release-artifacts
+      - name: Verify release artifacts
+        run: |
+          node --input-type=module <<'NODE'
+          import { createHash } from 'node:crypto';
+          import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+          import { execFileSync } from 'node:child_process';
+          import { join } from 'node:path';
+
+          const directory = 'release-artifacts';
+          const expectedPackageName = '@postman-cse/onboarding-aws-spec-discovery';
+          const allowed = new Set(['release.tgz', 'release-manifest.json']);
+          const maxManifestBytes = 64 * 1024;
+          const maxTarballBytes = 50 * 1024 * 1024;
+          const maxPackageJsonBytes = 64 * 1024;
+          const tarTimeoutMs = 10_000;
+
+          const entries = readdirSync(directory, { withFileTypes: true });
+          const names = entries.map((entry) => entry.name).sort();
+          for (const name of names) {
+            if (!allowed.has(name)) throw new Error(`unexpected release artifact: ${name}`);
+          }
+          for (const expected of allowed) {
+            if (!names.includes(expected)) throw new Error(`missing release artifact: ${expected}`);
+          }
+          for (const entry of entries) {
+            if (!entry.isFile()) throw new Error(`release artifact must be a regular file: ${entry.name}`);
+          }
+
+          const manifestPath = join(directory, 'release-manifest.json');
+          const tarballPath = join(directory, 'release.tgz');
+          const manifestStats = statSync(manifestPath);
+          const tarballStats = statSync(tarballPath);
+          if (!manifestStats.isFile() || !tarballStats.isFile()) throw new Error('release artifacts must be regular files');
+          if (manifestStats.size > maxManifestBytes) throw new Error('release-manifest.json exceeds size bound');
+          if (tarballStats.size > maxTarballBytes) throw new Error('release.tgz exceeds size bound');
+
+          const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+          if (manifest.schema_version !== 1) throw new Error('manifest schema_version must be 1');
+          for (const [field, expected] of Object.entries({
+            repository: process.env.GITHUB_REPOSITORY,
+            commit_sha: process.env.GITHUB_SHA,
+            tag: process.env.GITHUB_REF_NAME
+          })) {
+            if (manifest[field] !== expected) throw new Error(`manifest ${field} does not match release input`);
+          }
+          if (manifest.package_name !== expectedPackageName) {
+            throw new Error(`manifest package_name must be ${expectedPackageName}`);
+          }
+          const [major, minor, patch] = String(manifest.package_version).split('.');
+          const accepted = [`v${manifest.package_version}`, ...(patch === '0' ? [`v${major}.${minor}`] : [])];
+          if (!accepted.includes(process.env.GITHUB_REF_NAME)) {
+            throw new Error(`tag ${process.env.GITHUB_REF_NAME} does not match package version ${manifest.package_version}`);
+          }
+          if (!Array.isArray(manifest.artifacts) || manifest.artifacts.length !== 1) {
+            throw new Error('manifest artifacts must contain exactly release.tgz');
+          }
+          for (const artifact of manifest.artifacts) {
+            if (artifact.path !== 'release.tgz' || !/^[a-f0-9]{64}$/.test(artifact.sha256 ?? '')) {
+              throw new Error('manifest artifact is invalid');
+            }
+            const actual = createHash('sha256').update(readFileSync(join(directory, artifact.path))).digest('hex');
+            if (actual !== artifact.sha256) throw new Error(`checksum mismatch for ${artifact.path}`);
+          }
+
+          if (!existsSync(tarballPath)) throw new Error('missing release artifact: release.tgz');
+          const packageJsonText = execFileSync('tar', ['-xOf', tarballPath, 'package/package.json'], {
+            encoding: 'utf8',
+            timeout: tarTimeoutMs,
+            maxBuffer: maxPackageJsonBytes
+          });
+          const packageJson = JSON.parse(packageJsonText);
+          if (packageJson.name !== expectedPackageName) throw new Error('tarball package name does not match repository package');
+          if (packageJson.name !== manifest.package_name) throw new Error('tarball package name does not match manifest');
+          if (packageJson.version !== manifest.package_version) throw new Error('tarball package version does not match manifest');
+          NODE
+      - name: Publish or verify npm package
+        run: |
+          PACKAGE_NAME=$(node -p "require('./release-artifacts/release-manifest.json').package_name")
+          PACKAGE_VERSION=$(node -p "require('./release-artifacts/release-manifest.json').package_version")
+          LOCAL_INTEGRITY=$(node -e "const {createHash}=require('node:crypto');const {readFileSync}=require('node:fs');process.stdout.write('sha512-'+createHash('sha512').update(readFileSync('release-artifacts/release.tgz')).digest('base64'))")
+          if REMOTE_INTEGRITY=$(npm view "$PACKAGE_NAME@$PACKAGE_VERSION" dist.integrity 2>/dev/null); then
+            [ "$REMOTE_INTEGRITY" = "$LOCAL_INTEGRITY" ] || { echo "::error::Published npm integrity differs from staged tarball"; exit 1; }
+            echo "::notice::$PACKAGE_NAME@$PACKAGE_VERSION already has matching integrity."
+          else
+            npm publish ./release-artifacts/release.tgz --provenance --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: npm test
-      - run: npm run typecheck
-      - run: npm run verify:dist
-      - name: Install actionlint
-        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.11
-      - name: Run actionlint
-        run: |
-          ACTIONLINT_BIN="$(go env GOPATH)/bin/actionlint"
-          "$ACTIONLINT_BIN"
-      - name: Verify release tag matches package version
-        id: release_tag
-        run: |
-          if [[ "$GITHUB_REF" != refs/tags/v* ]]; then
-            echo "::error::Release workflow must run from a v* tag; got $GITHUB_REF"
-            exit 1
-          fi
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
-          PKG_VERSION=$(node -p "require('./package.json').version")
-          IFS='.' read -r MAJOR MINOR PATCH _ <<< "$PKG_VERSION"
-          PUBLISH_TAGS=("$PKG_VERSION")
-          if [ "${PATCH:-}" = "0" ] && [ -n "${MINOR:-}" ]; then
-            PUBLISH_TAGS+=("$MAJOR.$MINOR")
-          fi
-          for PUBLISH_TAG in "${PUBLISH_TAGS[@]}"; do
-            if [ "$TAG_VERSION" = "$PUBLISH_TAG" ]; then
-              echo "npm_publish=true" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          done
-          if [ "$TAG_VERSION" = "$MAJOR" ]; then
-            echo "npm_publish=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Tag v$TAG_VERSION is the rolling v1 alias for package version $PKG_VERSION; skipping npm publish."
-            exit 0
-          fi
-          if [ "${#PUBLISH_TAGS[@]}" -eq 2 ]; then
-            EXPECTED="v${PUBLISH_TAGS[0]}, v${PUBLISH_TAGS[1]}, or v$MAJOR"
-          else
-            EXPECTED="v${PUBLISH_TAGS[0]} or v$MAJOR"
-          fi
-          echo "::error::Tag v$TAG_VERSION does not match package.json version $PKG_VERSION; expected $EXPECTED"
-          exit 1
       - name: Publish GitHub release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           generate_release_notes: true
-      - uses: actions/setup-node@v7
-        if: steps.release_tag.outputs.npm_publish == 'true'
-        with:
-          node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
-      - name: Check npm package version
-        id: npm_package
-        if: steps.release_tag.outputs.npm_publish == 'true'
-        run: |
-          PKG_NAME=$(node -p "require('./package.json').name")
-          PKG_VERSION=$(node -p "require('./package.json').version")
-          if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then
-            echo "already_published=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::$PKG_NAME@$PKG_VERSION is already published; skipping npm publish."
-          else
-            echo "already_published=false" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Publish to npm
-        if: steps.release_tag.outputs.npm_publish == 'true' && steps.npm_package.outputs.already_published != 'true'
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Attach npm tarball to release
-        run: |
-          npm pack
-          mv ./*.tgz release.tgz
-      - name: Upload tarball
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          files: release.tgz
+          files: release-artifacts/release.tgz
 
   advance-major-alias:
-    # Keep the rolling major alias (e.g. v2) pointing at the newest published
-    # release so consumers pinned to the alias pick it up automatically.
-    # GITHUB_TOKEN pushes do not re-trigger workflows, so moving the alias
-    # here cannot recurse into another Release run.
-    needs: release
-    if: ${{ needs.release.outputs.npm_publish == 'true' }}
+    needs: [classify, publish]
+    if: ${{ needs.classify.outputs.release_kind == 'immutable' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v7
-      - name: Force-move rolling major alias tag
+        with:
+          fetch-depth: 1
+      - name: Advance rolling major alias monotonically
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          MAJOR="v${VERSION%%.*}"
-          if [ "$MAJOR" = "v$VERSION" ]; then
-            echo "::notice::Tag $GITHUB_REF_NAME is already a major alias; nothing to move."
-            exit 0
+          VERSION="$(node -p "require('./package.json').version")"; MAJOR="v${VERSION%%.*}"; CANDIDATE="$GITHUB_SHA"
+          git fetch --tags --force
+          if git rev-parse -q --verify "refs/tags/$MAJOR" >/dev/null; then
+            CURRENT_VERSION=$(git show "$MAJOR^{}:package.json" | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")
+            if [ "$(printf '%s\n%s\n' "$CURRENT_VERSION" "$VERSION" | sort -V | tail -n1)" != "$VERSION" ]; then
+              echo "::notice::Not moving $MAJOR backward from $CURRENT_VERSION to $VERSION"; exit 0
+            fi
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          COMMIT="$(git rev-parse "HEAD^{commit}")"
-          git tag -fa "$MAJOR" -m "Rolling $MAJOR alias -> $GITHUB_REF_NAME" "$COMMIT"
+          git config user.name "github-actions[bot]"; git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -fa "$MAJOR" -m "Rolling $MAJOR alias -> $GITHUB_REF_NAME" "$CANDIDATE"
           git push origin "$MAJOR" --force

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -6,8 +6,9 @@ Git tags and GitHub releases are the public release identifiers for this action.
 
 ## Tag policy
 
-- Immutable releases use `vMAJOR.MINOR.PATCH` tags.
-- The rolling major alias (`vMAJOR`, e.g. `v2`) is force-moved by the release workflow's `advance-major-alias` job after a successful immutable publish.
+- Immutable releases use `vMAJOR.MINOR.PATCH` tags that equal `v` plus the `package.json` version.
+- When the package patch is `0`, `vMAJOR.MINOR` is also an accepted immutable publish tag and maps to package version `MAJOR.MINOR.0`.
+- The rolling major alias (`vMAJOR`, e.g. `v2`) is force-moved by the release workflow's `advance-major-alias` job after a successful immutable publish; a direct `vMAJOR` push is a no-op alias invocation and does not publish.
 - Existing immutable release tags are never force-pushed or rewritten.
 - `v0` tags stay frozen at the last `v0` release.
 - Every immutable release tag has a GitHub release with generated notes.
@@ -27,7 +28,7 @@ Run the package validators from this directory before pushing an immutable tag:
 
 ## npm package
 
-The CLI publishes as `@postman-cse/onboarding-aws-spec-discovery` with versions that match the GitHub release tag. The rolling major alias updates the action channel and skips npm publishing.
+The CLI publishes as `@postman-cse/onboarding-aws-spec-discovery` with versions that match exact immutable GitHub release tags; zero-patch minor immutable tags (`vMAJOR.MINOR`) map to package version `MAJOR.MINOR.0`. The rolling major alias updates the action channel and skips npm publishing.
 
 ## Compatibility
 

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -114490,7 +114490,7 @@ var require_webidl = __commonJS({
   "node_modules/undici/lib/web/webidl/index.js"(exports2, module2) {
     "use strict";
     var assert = require("node:assert");
-    var { types, inspect } = require("node:util");
+    var { types, inspect: inspect2 } = require("node:util");
     var { markAsUncloneable } = require("node:worker_threads");
     var UNDEFINED = 1;
     var BOOLEAN = 2;
@@ -114681,7 +114681,7 @@ var require_webidl = __commonJS({
         case SYMBOL:
           return `Symbol(${V.description})`;
         case OBJECT:
-          return inspect(V);
+          return inspect2(V);
         case STRING:
           return `"${V}"`;
         case BIGINT:
@@ -182404,13 +182404,107 @@ var POSTMAN_ENDPOINT_PROFILES = {
   }
 };
 
+// src/lib/postman/pmak-diagnostics.ts
+var memo = /* @__PURE__ */ new Map();
+function normalizeApiBaseUrl(apiBaseUrl) {
+  return new URL(apiBaseUrl.trim()).toString().replace(/\/+$/, "");
+}
+function abortable(promise, signal) {
+  if (signal.aborted) {
+    return Promise.reject(signal.reason);
+  }
+  return Promise.race([
+    promise,
+    new Promise((_resolve, reject) => signal.addEventListener("abort", () => reject(signal.reason), { once: true }))
+  ]);
+}
+async function inspect(options, normalizedApiBase) {
+  const timeoutSignal = AbortSignal.timeout(options.timeoutMs ?? 2e3);
+  const signal = options.signal ? AbortSignal.any([options.signal, timeoutSignal]) : timeoutSignal;
+  try {
+    const response = await abortable(
+      (options.fetchImpl ?? fetch)(`${normalizedApiBase}/me`, {
+        method: "GET",
+        headers: { "x-api-key": options.apiKey },
+        signal
+      }),
+      signal
+    );
+    if (response.status === 401 || response.status === 403) {
+      return { kind: "invalid", status: response.status };
+    }
+    if (!response.ok) {
+      return { kind: "inconclusive", status: response.status };
+    }
+    const payload2 = await abortable(response.json(), signal);
+    if (!payload2 || typeof payload2 !== "object" || Array.isArray(payload2)) {
+      return { kind: "inconclusive", status: response.status };
+    }
+    const user = payload2.user;
+    if (!user || typeof user !== "object" || Array.isArray(user)) {
+      return { kind: "inconclusive", status: response.status };
+    }
+    const record = user;
+    const username = record.username;
+    const email = record.email;
+    if (typeof username === "string" && username.trim() || typeof email === "string" && email.trim()) {
+      return { kind: "personal", status: response.status };
+    }
+    if (Object.hasOwn(record, "username") && Object.hasOwn(record, "email") && (username === null || username === "") && (email === null || email === "")) {
+      return { kind: "service-account", status: response.status };
+    }
+    return { kind: "inconclusive", status: response.status };
+  } catch {
+    return { kind: "inconclusive" };
+  }
+}
+function inspectPmakIdentity(options) {
+  const normalizedApiBase = normalizeApiBaseUrl(options.apiBaseUrl);
+  const key = `${normalizedApiBase}\0${options.apiKey}`;
+  let pending = memo.get(key);
+  if (!pending) {
+    pending = inspect(options, normalizedApiBase);
+    memo.set(key, pending);
+    if (options.mode === "preflight") {
+      void pending.then((result) => {
+        if (result.kind === "inconclusive") memo.delete(key);
+      });
+    }
+  }
+  return pending;
+}
+function maskPmakDiagnostic(message, secrets) {
+  let masked = String(message);
+  for (const secret of secrets) {
+    if (secret) masked = masked.split(secret).join("***");
+  }
+  return Array.from(masked, (character) => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || code >= 127 && code <= 159 ? " " : character;
+  }).join("").replace(/\s+/g, " ").trim();
+}
+function formatRejectedMint(originalMintError, result) {
+  switch (result.kind) {
+    case "personal":
+      return `${originalMintError} Personal API key detected, cannot mint a service-account access token.`;
+    case "service-account":
+      return `${originalMintError} postman-api-key authenticates (GET /me OK) but was rejected by POST /service-account-tokens and lacks permission to mint access tokens.`;
+    case "invalid":
+      return `${originalMintError} postman-api-key is invalid, disabled, or expired.`;
+    default:
+      return originalMintError;
+  }
+}
+
 // src/lib/postman/token-provider.ts
 var MintError = class extends Error {
   permanent;
-  constructor(message, permanent) {
+  status;
+  constructor(message, permanent, status) {
     super(message);
     this.name = "MintError";
     this.permanent = permanent;
+    this.status = status;
   }
 };
 function extractAccessToken(payload2) {
@@ -182488,10 +182582,16 @@ var AccessTokenProvider = class {
     if (!response.ok) {
       const status = response.status;
       if (status === 401 || status === 403) {
-        throw new MintError(
+        const original = maskPmakDiagnostic(
           `postman: re-mint failed because the postman-api-key was rejected (PMAK rejected, HTTP ${status}); confirm it is a valid, enabled service-account PMAK for the intended team.`,
-          true
+          [this.apiKey, this.token]
         );
+        const diagnosis = await inspectPmakIdentity({
+          apiBaseUrl: this.apiBaseUrl,
+          apiKey: this.apiKey,
+          fetchImpl: this.fetchImpl
+        });
+        throw new MintError(formatRejectedMint(original, diagnosis), true, status);
       }
       if (status === 400 && body.toLowerCase().includes("service accounts not enabled")) {
         throw new MintError(
@@ -182499,7 +182599,7 @@ var AccessTokenProvider = class {
           true
         );
       }
-      throw new MintError(`postman: re-mint failed (service-account-tokens HTTP ${status}).`, false);
+      throw new MintError(`postman: re-mint failed (service-account-tokens HTTP ${status}).`, false, status);
     }
     let parsed;
     try {
@@ -182535,7 +182635,12 @@ async function prepareTelemetryCredentials(options) {
   if (!accessToken && apiKey && provider.canRefresh()) {
     try {
       await provider.refresh();
-    } catch {
+    } catch (error2) {
+      const message = error2 instanceof Error ? error2.message : String(error2);
+      options.onWarning?.(
+        `postman: telemetry credential enrichment failed. ${maskPmakDiagnostic(message, [apiKey, accessToken])}`
+      );
+      return { provider };
     }
   }
   const accountType = await resolveTelemetryAccountType(provider.current(), options.fetchImpl);
@@ -183150,7 +183255,8 @@ async function runCli(argv = process.argv.slice(2), runtime = {}) {
   telemetry.setTeamId(resolveTelemetryTeamId(config.inputEnv));
   const { accountType } = await prepareTelemetryCredentials({
     postmanApiKey: config.inputEnv.INPUT_POSTMAN_API_KEY ?? env2.POSTMAN_API_KEY,
-    postmanAccessToken: config.inputEnv.INPUT_POSTMAN_ACCESS_TOKEN ?? env2.POSTMAN_ACCESS_TOKEN
+    postmanAccessToken: config.inputEnv.INPUT_POSTMAN_ACCESS_TOKEN ?? env2.POSTMAN_ACCESS_TOKEN,
+    onWarning: (message) => reporter.warning(message)
   });
   try {
     const result = await execute(inputs, {

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -4501,7 +4501,7 @@ var require_webidl = __commonJS({
   "node_modules/undici/lib/web/webidl/index.js"(exports2, module2) {
     "use strict";
     var assert = require("node:assert");
-    var { types, inspect } = require("node:util");
+    var { types, inspect: inspect2 } = require("node:util");
     var { markAsUncloneable } = require("node:worker_threads");
     var UNDEFINED = 1;
     var BOOLEAN = 2;
@@ -4692,7 +4692,7 @@ var require_webidl = __commonJS({
         case SYMBOL:
           return `Symbol(${V.description})`;
         case OBJECT:
-          return inspect(V);
+          return inspect2(V);
         case STRING:
           return `"${V}"`;
         case BIGINT:
@@ -185003,13 +185003,107 @@ var POSTMAN_ENDPOINT_PROFILES = {
   }
 };
 
+// src/lib/postman/pmak-diagnostics.ts
+var memo = /* @__PURE__ */ new Map();
+function normalizeApiBaseUrl(apiBaseUrl) {
+  return new URL(apiBaseUrl.trim()).toString().replace(/\/+$/, "");
+}
+function abortable(promise, signal) {
+  if (signal.aborted) {
+    return Promise.reject(signal.reason);
+  }
+  return Promise.race([
+    promise,
+    new Promise((_resolve, reject) => signal.addEventListener("abort", () => reject(signal.reason), { once: true }))
+  ]);
+}
+async function inspect(options, normalizedApiBase) {
+  const timeoutSignal = AbortSignal.timeout(options.timeoutMs ?? 2e3);
+  const signal = options.signal ? AbortSignal.any([options.signal, timeoutSignal]) : timeoutSignal;
+  try {
+    const response = await abortable(
+      (options.fetchImpl ?? fetch)(`${normalizedApiBase}/me`, {
+        method: "GET",
+        headers: { "x-api-key": options.apiKey },
+        signal
+      }),
+      signal
+    );
+    if (response.status === 401 || response.status === 403) {
+      return { kind: "invalid", status: response.status };
+    }
+    if (!response.ok) {
+      return { kind: "inconclusive", status: response.status };
+    }
+    const payload2 = await abortable(response.json(), signal);
+    if (!payload2 || typeof payload2 !== "object" || Array.isArray(payload2)) {
+      return { kind: "inconclusive", status: response.status };
+    }
+    const user = payload2.user;
+    if (!user || typeof user !== "object" || Array.isArray(user)) {
+      return { kind: "inconclusive", status: response.status };
+    }
+    const record = user;
+    const username = record.username;
+    const email = record.email;
+    if (typeof username === "string" && username.trim() || typeof email === "string" && email.trim()) {
+      return { kind: "personal", status: response.status };
+    }
+    if (Object.hasOwn(record, "username") && Object.hasOwn(record, "email") && (username === null || username === "") && (email === null || email === "")) {
+      return { kind: "service-account", status: response.status };
+    }
+    return { kind: "inconclusive", status: response.status };
+  } catch {
+    return { kind: "inconclusive" };
+  }
+}
+function inspectPmakIdentity(options) {
+  const normalizedApiBase = normalizeApiBaseUrl(options.apiBaseUrl);
+  const key = `${normalizedApiBase}\0${options.apiKey}`;
+  let pending = memo.get(key);
+  if (!pending) {
+    pending = inspect(options, normalizedApiBase);
+    memo.set(key, pending);
+    if (options.mode === "preflight") {
+      void pending.then((result) => {
+        if (result.kind === "inconclusive") memo.delete(key);
+      });
+    }
+  }
+  return pending;
+}
+function maskPmakDiagnostic(message, secrets) {
+  let masked = String(message);
+  for (const secret of secrets) {
+    if (secret) masked = masked.split(secret).join("***");
+  }
+  return Array.from(masked, (character) => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || code >= 127 && code <= 159 ? " " : character;
+  }).join("").replace(/\s+/g, " ").trim();
+}
+function formatRejectedMint(originalMintError, result) {
+  switch (result.kind) {
+    case "personal":
+      return `${originalMintError} Personal API key detected, cannot mint a service-account access token.`;
+    case "service-account":
+      return `${originalMintError} postman-api-key authenticates (GET /me OK) but was rejected by POST /service-account-tokens and lacks permission to mint access tokens.`;
+    case "invalid":
+      return `${originalMintError} postman-api-key is invalid, disabled, or expired.`;
+    default:
+      return originalMintError;
+  }
+}
+
 // src/lib/postman/token-provider.ts
 var MintError = class extends Error {
   permanent;
-  constructor(message, permanent) {
+  status;
+  constructor(message, permanent, status) {
     super(message);
     this.name = "MintError";
     this.permanent = permanent;
+    this.status = status;
   }
 };
 function extractAccessToken(payload2) {
@@ -185087,10 +185181,16 @@ var AccessTokenProvider = class {
     if (!response.ok) {
       const status = response.status;
       if (status === 401 || status === 403) {
-        throw new MintError(
+        const original = maskPmakDiagnostic(
           `postman: re-mint failed because the postman-api-key was rejected (PMAK rejected, HTTP ${status}); confirm it is a valid, enabled service-account PMAK for the intended team.`,
-          true
+          [this.apiKey, this.token]
         );
+        const diagnosis = await inspectPmakIdentity({
+          apiBaseUrl: this.apiBaseUrl,
+          apiKey: this.apiKey,
+          fetchImpl: this.fetchImpl
+        });
+        throw new MintError(formatRejectedMint(original, diagnosis), true, status);
       }
       if (status === 400 && body.toLowerCase().includes("service accounts not enabled")) {
         throw new MintError(
@@ -185098,7 +185198,7 @@ var AccessTokenProvider = class {
           true
         );
       }
-      throw new MintError(`postman: re-mint failed (service-account-tokens HTTP ${status}).`, false);
+      throw new MintError(`postman: re-mint failed (service-account-tokens HTTP ${status}).`, false, status);
     }
     let parsed;
     try {
@@ -185134,7 +185234,12 @@ async function prepareTelemetryCredentials(options) {
   if (!accessToken && apiKey && provider.canRefresh()) {
     try {
       await provider.refresh();
-    } catch {
+    } catch (error3) {
+      const message = error3 instanceof Error ? error3.message : String(error3);
+      options.onWarning?.(
+        `postman: telemetry credential enrichment failed. ${maskPmakDiagnostic(message, [apiKey, accessToken])}`
+      );
+      return { provider };
     }
   }
   const accountType = await resolveTelemetryAccountType(provider.current(), options.fetchImpl);
@@ -185547,7 +185652,8 @@ async function runAction(actionCore = core_exports, dependencies = {}) {
   const { accountType } = await prepareTelemetryCredentials({
     postmanApiKey,
     postmanAccessToken,
-    onToken: (token) => actionCore.setSecret?.(token)
+    onToken: (token) => actionCore.setSecret?.(token),
+    onWarning: (message) => actionCore.warning(message)
   });
   try {
     const result = await runActionInner(actionCore, dependencies);

--- a/scripts/classify-release.mjs
+++ b/scripts/classify-release.mjs
@@ -1,0 +1,52 @@
+import console from 'node:console';
+import { appendFileSync, readFileSync } from 'node:fs';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+/**
+ * @param {{ ref: string, refName: string, packageVersion: string }} input
+ * @returns {{ release_kind: 'immutable' | 'alias', npm_publish: 'true' | 'false' }}
+ */
+export function classifyRelease({ ref, refName, packageVersion }) {
+  const [major, minor, patch] = String(packageVersion).split('.');
+  const accepted = `expected v${packageVersion}, v${major}.${minor} when patch is zero, or v${major}`;
+  if (!ref?.startsWith('refs/tags/v')) {
+    throw new Error(`Release workflow must run from an accepted immutable tag; got ${ref}; ${accepted}`);
+  }
+  const tagVersion = String(refName ?? '').startsWith('v') ? String(refName).slice(1) : '';
+  if (tagVersion === packageVersion || (patch === '0' && tagVersion === `${major}.${minor}`)) {
+    return { release_kind: 'immutable', npm_publish: 'true' };
+  }
+  if (tagVersion === major) {
+    return { release_kind: 'alias', npm_publish: 'false' };
+  }
+  throw new Error(`Release workflow must run from an accepted immutable tag; got ${refName}; ${accepted}`);
+}
+
+function writeOutput(key, value) {
+  const output = process.env.GITHUB_OUTPUT;
+  if (!output) throw new Error('GITHUB_OUTPUT is required');
+  appendFileSync(output, `${key}=${value}\n`);
+}
+
+function main() {
+  const packageVersion = JSON.parse(readFileSync('package.json', 'utf8')).version;
+  const ref = process.env.GITHUB_REF ?? '';
+  const refName = process.env.GITHUB_REF_NAME ?? '';
+  const result = classifyRelease({ ref, refName, packageVersion });
+  writeOutput('release_kind', result.release_kind);
+  writeOutput('npm_publish', result.npm_publish);
+  if (result.release_kind === 'alias') {
+    console.log('::notice::Rolling alias invocation; no release work will run.');
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`::error::${message}`);
+    process.exit(1);
+  }
+}

--- a/scripts/verify-release-artifacts.mjs
+++ b/scripts/verify-release-artifacts.mjs
@@ -1,0 +1,102 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import process from 'node:process';
+import console from 'node:console';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const EXPECTED_PACKAGE_NAME = '@postman-cse/onboarding-aws-spec-discovery';
+const ALLOWED_ARTIFACT_PATHS = ['release.tgz', 'release-manifest.json'];
+const MAX_MANIFEST_BYTES = 64 * 1024;
+const MAX_TARBALL_BYTES = 50 * 1024 * 1024;
+const MAX_PACKAGE_JSON_BYTES = 64 * 1024;
+const TAR_TIMEOUT_MS = 10_000;
+
+const sha256 = (path) => createHash('sha256').update(readFileSync(path)).digest('hex');
+
+export function acceptedImmutableTags(version) {
+  const [major, minor, patch] = version.split('.');
+  return [`v${version}`, ...(patch === '0' ? [`v${major}.${minor}`] : [])];
+}
+
+export function verifyNpmIntegrity(tarballPath, publishedIntegrity) {
+  const localIntegrity = `sha512-${createHash('sha512').update(readFileSync(tarballPath)).digest('base64')}`;
+  if (publishedIntegrity !== localIntegrity) throw new Error('published npm integrity differs from staged tarball');
+  return localIntegrity;
+}
+
+function assertRegularFile(path, label) {
+  if (!existsSync(path)) throw new Error(`missing release artifact: ${label}`);
+  const stats = statSync(path);
+  if (!stats.isFile()) throw new Error(`release artifact must be a regular file: ${label}`);
+  return stats;
+}
+
+export function validateReleaseArtifacts(directory, { repository, commitSha, tag }) {
+  const entries = readdirSync(directory, { withFileTypes: true });
+  const names = entries.map((entry) => entry.name).sort();
+  for (const name of names) {
+    if (!ALLOWED_ARTIFACT_PATHS.includes(name)) throw new Error(`unexpected release artifact: ${name}`);
+  }
+  for (const expected of ALLOWED_ARTIFACT_PATHS) {
+    if (!names.includes(expected)) throw new Error(`missing release artifact: ${expected}`);
+  }
+  for (const entry of entries) {
+    if (!entry.isFile()) throw new Error(`release artifact must be a regular file: ${entry.name}`);
+  }
+
+  const manifestPath = join(directory, 'release-manifest.json');
+  const tarballPath = join(directory, 'release.tgz');
+  const manifestStats = assertRegularFile(manifestPath, 'release-manifest.json');
+  const tarballStats = assertRegularFile(tarballPath, 'release.tgz');
+  if (manifestStats.size > MAX_MANIFEST_BYTES) throw new Error('release-manifest.json exceeds size bound');
+  if (tarballStats.size > MAX_TARBALL_BYTES) throw new Error('release.tgz exceeds size bound');
+
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  if (manifest.schema_version !== 1) throw new Error('manifest schema_version must be 1');
+  for (const [field, expected] of Object.entries({ repository, commit_sha: commitSha, tag })) {
+    if (manifest[field] !== expected) throw new Error(`manifest ${field} does not match release input`);
+  }
+  if (manifest.package_name !== EXPECTED_PACKAGE_NAME) {
+    throw new Error(`manifest package_name must be ${EXPECTED_PACKAGE_NAME}`);
+  }
+  if (!acceptedImmutableTags(manifest.package_version).includes(tag)) {
+    throw new Error(`tag ${tag} does not match package version ${manifest.package_version}`);
+  }
+  if (!Array.isArray(manifest.artifacts) || manifest.artifacts.length !== 1) {
+    throw new Error('manifest artifacts must contain exactly release.tgz');
+  }
+  for (const artifact of manifest.artifacts) {
+    if (artifact.path !== 'release.tgz' || !/^[a-f0-9]{64}$/.test(artifact.sha256 ?? '')) {
+      throw new Error('manifest artifact is invalid');
+    }
+    if (sha256(join(directory, artifact.path)) !== artifact.sha256) {
+      throw new Error(`checksum mismatch for ${artifact.path}`);
+    }
+  }
+
+  const packageJsonText = execFileSync('tar', ['-xOf', tarballPath, 'package/package.json'], {
+    encoding: 'utf8',
+    timeout: TAR_TIMEOUT_MS,
+    maxBuffer: MAX_PACKAGE_JSON_BYTES
+  });
+  const packageJson = JSON.parse(packageJsonText);
+  if (packageJson.name !== EXPECTED_PACKAGE_NAME) throw new Error('tarball package name does not match repository package');
+  if (packageJson.name !== manifest.package_name) throw new Error('tarball package name does not match manifest');
+  if (packageJson.version !== manifest.package_version) throw new Error('tarball package version does not match manifest');
+  return manifest;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    validateReleaseArtifacts(process.argv[2] ?? '.', {
+      repository: process.env.GITHUB_REPOSITORY,
+      commitSha: process.env.GITHUB_SHA,
+      tag: process.env.GITHUB_REF_NAME
+    });
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -277,7 +277,8 @@ export async function runCli(
   // present, resolve account_type once, best-effort, before either completion emit.
   const { accountType } = await prepareTelemetryCredentials({
     postmanApiKey: config.inputEnv.INPUT_POSTMAN_API_KEY ?? env.POSTMAN_API_KEY,
-    postmanAccessToken: config.inputEnv.INPUT_POSTMAN_ACCESS_TOKEN ?? env.POSTMAN_ACCESS_TOKEN
+    postmanAccessToken: config.inputEnv.INPUT_POSTMAN_ACCESS_TOKEN ?? env.POSTMAN_ACCESS_TOKEN,
+    onWarning: (message) => reporter.warning(message)
   });
   try {
     const result = await execute(inputs, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,8 @@ export async function runAction(
   const { accountType } = await prepareTelemetryCredentials({
     postmanApiKey,
     postmanAccessToken,
-    onToken: (token) => actionCore.setSecret?.(token)
+    onToken: (token) => actionCore.setSecret?.(token),
+    onWarning: (message) => actionCore.warning(message)
   });
   try {
     const result = await runActionInner(actionCore, dependencies);

--- a/src/lib/postman/pmak-diagnostics.ts
+++ b/src/lib/postman/pmak-diagnostics.ts
@@ -1,0 +1,125 @@
+export type PmakDiagnosticKind = 'personal' | 'service-account' | 'invalid' | 'inconclusive';
+
+export interface PmakDiagnosticResult {
+  kind: PmakDiagnosticKind;
+  status?: number;
+  payload?: Record<string, unknown>;
+}
+
+export interface InspectPmakIdentityOptions {
+  apiBaseUrl: string;
+  apiKey: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  mode?: 'diagnostic' | 'preflight';
+}
+
+const memo = new Map<string, Promise<PmakDiagnosticResult>>();
+
+export function __resetPmakDiagnosticMemo(): void {
+  memo.clear();
+}
+
+function normalizeApiBaseUrl(apiBaseUrl: string): string {
+  return new URL(apiBaseUrl.trim()).toString().replace(/\/+$/, '');
+}
+
+function abortable<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    return Promise.reject(signal.reason);
+  }
+  return Promise.race([
+    promise,
+    new Promise<T>((_resolve, reject) => signal.addEventListener('abort', () => reject(signal.reason), { once: true }))
+  ]);
+}
+
+async function inspect(options: InspectPmakIdentityOptions, normalizedApiBase: string): Promise<PmakDiagnosticResult> {
+  const timeoutSignal = AbortSignal.timeout(options.timeoutMs ?? 2000);
+  const signal = options.signal ? AbortSignal.any([options.signal, timeoutSignal]) : timeoutSignal;
+  try {
+    const response = await abortable(
+      (options.fetchImpl ?? fetch)(`${normalizedApiBase}/me`, {
+        method: 'GET',
+        headers: { 'x-api-key': options.apiKey },
+        signal
+      }),
+      signal
+    );
+    if (response.status === 401 || response.status === 403) {
+      return { kind: 'invalid', status: response.status };
+    }
+    if (!response.ok) {
+      return { kind: 'inconclusive', status: response.status };
+    }
+    const payload = await abortable(response.json(), signal);
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+      return { kind: 'inconclusive', status: response.status };
+    }
+    const user = (payload as Record<string, unknown>).user;
+    if (!user || typeof user !== 'object' || Array.isArray(user)) {
+      return { kind: 'inconclusive', status: response.status };
+    }
+    const record = user as Record<string, unknown>;
+    const username = record.username;
+    const email = record.email;
+    if ((typeof username === 'string' && username.trim()) || (typeof email === 'string' && email.trim())) {
+      return { kind: 'personal', status: response.status };
+    }
+    if (
+      Object.hasOwn(record, 'username') &&
+      Object.hasOwn(record, 'email') &&
+      (username === null || username === '') &&
+      (email === null || email === '')
+    ) {
+      return { kind: 'service-account', status: response.status };
+    }
+    return { kind: 'inconclusive', status: response.status };
+  } catch {
+    return { kind: 'inconclusive' };
+  }
+}
+
+export function inspectPmakIdentity(options: InspectPmakIdentityOptions): Promise<PmakDiagnosticResult> {
+  const normalizedApiBase = normalizeApiBaseUrl(options.apiBaseUrl);
+  const key = `${normalizedApiBase}\u0000${options.apiKey}`;
+  let pending = memo.get(key);
+  if (!pending) {
+    pending = inspect(options, normalizedApiBase);
+    memo.set(key, pending);
+    if (options.mode === 'preflight') {
+      void pending.then((result) => {
+        if (result.kind === 'inconclusive') memo.delete(key);
+      });
+    }
+  }
+  return pending;
+}
+
+export function maskPmakDiagnostic(message: string, secrets: readonly (string | undefined)[]): string {
+  let masked = String(message);
+  for (const secret of secrets) {
+    if (secret) masked = masked.split(secret).join('***');
+  }
+  return Array.from(masked, (character) => {
+    const code = character.charCodeAt(0);
+    return code <= 0x1f || (code >= 0x7f && code <= 0x9f) ? ' ' : character;
+  })
+    .join('')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function formatRejectedMint(originalMintError: string, result: PmakDiagnosticResult): string {
+  switch (result.kind) {
+    case 'personal':
+      return `${originalMintError} Personal API key detected, cannot mint a service-account access token.`;
+    case 'service-account':
+      return `${originalMintError} postman-api-key authenticates (GET /me OK) but was rejected by POST /service-account-tokens and lacks permission to mint access tokens.`;
+    case 'invalid':
+      return `${originalMintError} postman-api-key is invalid, disabled, or expired.`;
+    default:
+      return originalMintError;
+  }
+}

--- a/src/lib/postman/telemetry-credentials.ts
+++ b/src/lib/postman/telemetry-credentials.ts
@@ -1,12 +1,14 @@
 import { resolveTelemetryAccountType } from './credential-identity.js';
 import { AccessTokenProvider } from './token-provider.js';
 import { POSTMAN_ENDPOINT_PROFILES } from './base-urls.js';
+import { maskPmakDiagnostic } from './pmak-diagnostics.js';
 
 export interface PrepareTelemetryCredentialsOptions {
   postmanApiKey?: string;
   postmanAccessToken?: string;
   apiBaseUrl?: string;
   onToken?: (token: string) => void;
+  onWarning?: (message: string) => void;
   fetchImpl?: typeof fetch;
 }
 
@@ -45,8 +47,13 @@ export async function prepareTelemetryCredentials(
   if (!accessToken && apiKey && provider.canRefresh()) {
     try {
       await provider.refresh();
-    } catch {
+    } catch (error) {
       // Telemetry-only path: discovery continues without account_type enrichment.
+      const message = error instanceof Error ? error.message : String(error);
+      options.onWarning?.(
+        `postman: telemetry credential enrichment failed. ${maskPmakDiagnostic(message, [apiKey, accessToken])}`
+      );
+      return { provider };
     }
   }
 

--- a/src/lib/postman/token-provider.ts
+++ b/src/lib/postman/token-provider.ts
@@ -1,5 +1,6 @@
 import { retry } from '../retry.js';
 import { POSTMAN_ENDPOINT_PROFILES } from './base-urls.js';
+import { formatRejectedMint, inspectPmakIdentity, maskPmakDiagnostic } from './pmak-diagnostics.js';
 
 export interface AccessTokenProviderOptions {
   /** Current access token (from action input or a prior mint). May be empty. */
@@ -22,11 +23,13 @@ export interface AccessTokenProviderOptions {
 
 class MintError extends Error {
   readonly permanent: boolean;
+  readonly status?: number;
 
-  constructor(message: string, permanent: boolean) {
+  constructor(message: string, permanent: boolean, status?: number) {
     super(message);
     this.name = 'MintError';
     this.permanent = permanent;
+    this.status = status;
   }
 }
 
@@ -125,11 +128,17 @@ export class AccessTokenProvider {
     if (!response.ok) {
       const status = response.status;
       if (status === 401 || status === 403) {
-        throw new MintError(
+        const original = maskPmakDiagnostic(
           `postman: re-mint failed because the postman-api-key was rejected (PMAK rejected, HTTP ${status}); ` +
             'confirm it is a valid, enabled service-account PMAK for the intended team.',
-          true
+          [this.apiKey, this.token]
         );
+        const diagnosis = await inspectPmakIdentity({
+          apiBaseUrl: this.apiBaseUrl,
+          apiKey: this.apiKey,
+          fetchImpl: this.fetchImpl
+        });
+        throw new MintError(formatRejectedMint(original, diagnosis), true, status);
       }
       if (status === 400 && body.toLowerCase().includes('service accounts not enabled')) {
         throw new MintError(
@@ -138,7 +147,7 @@ export class AccessTokenProvider {
           true
         );
       }
-      throw new MintError(`postman: re-mint failed (service-account-tokens HTTP ${status}).`, false);
+      throw new MintError(`postman: re-mint failed (service-account-tokens HTTP ${status}).`, false, status);
     }
 
     let parsed: unknown;

--- a/tests/ci-workflow.test.ts
+++ b/tests/ci-workflow.test.ts
@@ -103,6 +103,7 @@ describe('CI workflow contract', () => {
 
     const runGates = namedStep(windows, 'Run gates');
     expect(runGates).toContain('shell: pwsh');
+    expect(runGates).toContain("$ErrorActionPreference = 'Stop'");
     expect(runGates).toContain('$maxParallelGates = 2');
     expect(runGates).toContain('while ($jobs.Count -ge $maxParallelGates)');
     expect(runGates).toContain('Start-Job');
@@ -117,6 +118,9 @@ describe('CI workflow contract', () => {
     expect(runGates).toContain('& npm @npmArgs');
     expect(runGates).toContain('if ($LASTEXITCODE -ne 0) { throw "gate failed with exit code $LASTEXITCODE" }');
     expect(runGates).toContain('-ArgumentList (,$check.Args)');
+    expect(runGates.match(/Receive-Job -Job \$[^ ]+ -ErrorAction Continue 2>&1 \| Write-Output/g) ?? []).toHaveLength(2);
+    expect(runGates).toContain('Write-Output "::group::$($finished.Name)"');
+    expect(runGates).toContain('Write-Output "::group::$($job.Name)"');
 
     expect(runGates).toContain('gate:$($check.Name)=pass');
     expect(runGates).toContain('gate:$($check.Name)=fail');
@@ -126,7 +130,7 @@ describe('CI workflow contract', () => {
   });
 
   it(
-    'executes the Windows Run gates body and fails the process when npm test exits nonzero',
+    'drains Windows gate diagnostics before failing the process when npm test exits nonzero',
     () => {
       const script = extractWindowsRunGatesBody(workflow);
       expect(script).toContain('& npm @npmArgs');
@@ -141,7 +145,7 @@ describe('CI workflow contract', () => {
               name: 'aws-ci-windows-gates-fixture',
               private: true,
               scripts: {
-                lint: 'node -e "process.exit(0)"',
+                lint: 'node -e "console.error(\'benign stderr from passing lint\')"',
                 test: 'node -e "process.exit(1)"',
                 typecheck: 'node -e "process.exit(0)"',
                 'verify:dist:assert': 'node -e "process.exit(0)"',
@@ -163,6 +167,11 @@ describe('CI workflow contract', () => {
         expect(result.error, output).toBeUndefined();
         expect(result.signal, output).toBeNull();
         expect(result.status, output).not.toBe(0);
+        expect(output).toContain('benign stderr from passing lint');
+        expect(output).toContain('::group::lint');
+        expect(output).toContain('::group::test');
+        expect(output).toContain('::group::typecheck');
+        expect(output).toContain('::group::dist');
         expect(output).toContain('gate:lint=pass');
         expect(output).toContain('gate:test=fail');
         expect(output).toContain('gate:typecheck=pass');

--- a/tests/ci-workflow.test.ts
+++ b/tests/ci-workflow.test.ts
@@ -1,0 +1,180 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+import { describe, expect, it } from 'vitest';
+
+const workflow = readFileSync(join(process.cwd(), '.github/workflows/ci.yml'), 'utf8');
+
+/** Extract one top-level job block: `  <id>:` through the next job header or EOF. */
+function jobText(source: string, jobId: string): string {
+  const jobsBody = source.match(/^jobs:\n([\s\S]*)$/m)?.[1] ?? '';
+  const header = `  ${jobId}:\n`;
+  const start = jobsBody.indexOf(header);
+  if (start < 0) return '';
+  const rest = jobsBody.slice(start + header.length);
+  const nextJob = rest.search(/^ {2}[a-zA-Z0-9_-]+:\n/m);
+  return header + (nextJob < 0 ? rest : rest.slice(0, nextJob));
+}
+
+function namedStep(source: string, name: string): string {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = source.match(new RegExp(`      - name: ${escapedName}\\n[\\s\\S]*?(?=\\n      - |\\n?$)`));
+  return match?.[0] ?? '';
+}
+
+/** Ordered gate names launched via `run <name> ...` (excludes the `run()` helper definition). */
+function linuxQueuedGates(runGates: string): string[] {
+  return [...runGates.matchAll(/^\s+run ([a-zA-Z0-9_-]+)\s+/gm)].map((m) => m[1]!);
+}
+
+/** Exact Windows `Run gates` PowerShell body under `run: |`, with YAML indent stripped. */
+function extractWindowsRunGatesBody(source: string): string {
+  const windows = jobText(source, 'windows');
+  const match = windows.match(/ {6}- name: Run gates\n {8}shell: pwsh\n {8}run: \|\n([\s\S]*)$/);
+  if (!match?.[1]) {
+    throw new Error('Windows Run gates pwsh body not found');
+  }
+  return match[1]
+    .replace(/\n$/, '')
+    .split('\n')
+    .map((line) => (line.startsWith('          ') ? line.slice(10) : line))
+    .join('\n');
+}
+
+const linux = jobText(workflow, 'gate');
+const windows = jobText(workflow, 'windows');
+
+describe('CI workflow contract', () => {
+  it('supersedes PRs only and bundles once before bounded Linux gates', () => {
+    expect(workflow).toContain('group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}');
+    expect(workflow).toContain("cancel-in-progress: ${{ github.event_name == 'pull_request' }}");
+
+    expect(linux.match(/^\s*- run: npm run bundle\s*$/gm) ?? []).toHaveLength(1);
+    expect(linux.indexOf('- run: npm run bundle')).toBeLessThan(linux.indexOf('- name: Run gates'));
+
+    const runGates = namedStep(linux, 'Run gates');
+    expect(runGates).toContain('MAX_PARALLEL_GATES=2');
+    expect(runGates).toContain('while [ "${#pid[@]}" -ge "$MAX_PARALLEL_GATES" ]; do finish_one; done');
+    expect(runGates).toContain('while [ "${#pid[@]}" -gt 0 ]; do finish_one; done');
+    expect(runGates).toContain('wait -n -p finished_pid');
+
+    expect(linuxQueuedGates(runGates)).toEqual([
+      'lint',
+      'typecheck',
+      'test',
+      'dist',
+      'actionlint',
+      'commitlint',
+    ]);
+    expect(runGates).toContain('run lint       npm run lint');
+    expect(runGates).toContain('run typecheck  npm run typecheck');
+    expect(runGates).toContain('run test       npm test');
+    expect(runGates).toContain('run dist       npm run verify:dist:assert');
+    expect(runGates).toContain('run actionlint "$ACTIONLINT_BIN"');
+    expect(runGates).toContain('if [ "${{ github.event_name }}" = "pull_request" ]; then');
+    expect(runGates).toContain('run commitlint npx commitlint \\');
+    expect(runGates).toContain('--from "${{ github.event.pull_request.base.sha }}"');
+    expect(runGates).toContain('--to "${{ github.event.pull_request.head.sha }}"');
+
+    expect(runGates).toContain('gate:$n=pass');
+    expect(runGates).toContain('gate:$n=fail');
+    expect(runGates).toContain('::group::$n');
+    expect(runGates).toContain('exit $fail');
+  });
+
+  it('pins actionlint 1.7.11 at $RUNNER_TEMP/actionlint with PR-only commitlint history', () => {
+    const install = namedStep(linux, 'Install actionlint');
+    expect(install).toContain('download-actionlint.bash) 1.7.11 "$RUNNER_TEMP"');
+    expect(install).toContain('ACTIONLINT_BIN="$RUNNER_TEMP/actionlint"');
+    expect(workflow).not.toContain('actions/setup-go');
+    expect(workflow).not.toContain('go install github.com/rhysd/actionlint');
+
+    expect(linux).toContain('fetch-depth: 0');
+    expect(windows).not.toMatch(/^\s*fetch-depth:\s*/m);
+    expect(windows).not.toContain('commitlint');
+  });
+
+  it('preserves Windows coverage with a bundle-once bounded queue and native exit propagation', () => {
+    expect(windows).toContain('runs-on: windows-latest');
+    expect(windows.match(/^\s*- run: npm run bundle\s*$/gm) ?? []).toHaveLength(1);
+    expect(windows.indexOf('- run: npm run bundle')).toBeLessThan(windows.indexOf('- name: Run gates'));
+
+    const runGates = namedStep(windows, 'Run gates');
+    expect(runGates).toContain('shell: pwsh');
+    expect(runGates).toContain('$maxParallelGates = 2');
+    expect(runGates).toContain('while ($jobs.Count -ge $maxParallelGates)');
+    expect(runGates).toContain('Start-Job');
+
+    expect(runGates).toContain("@{ Name = 'lint'; Args = @('run', 'lint') }");
+    expect(runGates).toContain("@{ Name = 'test'; Args = @('test') }");
+    expect(runGates).toContain("@{ Name = 'typecheck'; Args = @('run', 'typecheck') }");
+    expect(runGates).toContain("@{ Name = 'dist'; Args = @('run', 'verify:dist:assert') }");
+    expect(runGates.match(/@\{ Name = '[^']+'; Args = @[^}]+\}/g) ?? []).toHaveLength(4);
+
+    expect(runGates).not.toContain('Invoke-Expression');
+    expect(runGates).toContain('& npm @npmArgs');
+    expect(runGates).toContain('if ($LASTEXITCODE -ne 0) { throw "gate failed with exit code $LASTEXITCODE" }');
+    expect(runGates).toContain('-ArgumentList (,$check.Args)');
+
+    expect(runGates).toContain('gate:$($check.Name)=pass');
+    expect(runGates).toContain('gate:$($check.Name)=fail');
+    expect(runGates).toContain('if ($failed) { exit 1 }');
+    expect(runGates).not.toContain('actionlint');
+    expect(runGates).not.toContain('commitlint');
+  });
+
+  it(
+    'executes the Windows Run gates body and fails the process when npm test exits nonzero',
+    () => {
+      const script = extractWindowsRunGatesBody(workflow);
+      expect(script).toContain('& npm @npmArgs');
+      expect(script).not.toContain('Invoke-Expression');
+
+      const fixture = mkdtempSync(join(tmpdir(), 'aws-ci-windows-gates-'));
+      try {
+        writeFileSync(
+          join(fixture, 'package.json'),
+          `${JSON.stringify(
+            {
+              name: 'aws-ci-windows-gates-fixture',
+              private: true,
+              scripts: {
+                lint: 'node -e "process.exit(0)"',
+                test: 'node -e "process.exit(1)"',
+                typecheck: 'node -e "process.exit(0)"',
+                'verify:dist:assert': 'node -e "process.exit(0)"',
+              },
+            },
+            null,
+            2,
+          )}\n`,
+        );
+        writeFileSync(join(fixture, 'run-gates.ps1'), `${script}\n`);
+
+        const result = spawnSync('pwsh', ['-NoProfile', '-File', 'run-gates.ps1'], {
+          cwd: fixture,
+          encoding: 'utf8',
+          timeout: 30_000,
+        });
+        const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+
+        expect(result.error, output).toBeUndefined();
+        expect(result.signal, output).toBeNull();
+        expect(result.status, output).not.toBe(0);
+        expect(output).toContain('gate:lint=pass');
+        expect(output).toContain('gate:test=fail');
+        expect(output).toContain('gate:typecheck=pass');
+        expect(output).toContain('gate:dist=pass');
+        expect(output).toMatch(/gate:lint=(?:pass|fail)/);
+        expect(output).toMatch(/gate:test=(?:pass|fail)/);
+        expect(output).toMatch(/gate:typecheck=(?:pass|fail)/);
+        expect(output).toMatch(/gate:dist=(?:pass|fail)/);
+      } finally {
+        rmSync(fixture, { recursive: true, force: true });
+      }
+    },
+    60_000,
+  );
+});

--- a/tests/credential-identity.test.ts
+++ b/tests/credential-identity.test.ts
@@ -6,6 +6,10 @@ import {
   resolveSessionIdentity,
   resolveTelemetryAccountType
 } from '../src/lib/postman/credential-identity.js';
+import {
+  __resetPmakDiagnosticMemo,
+  inspectPmakIdentity
+} from '../src/lib/postman/pmak-diagnostics.js';
 
 const IAPUB_BASE = 'https://iapub.postman.co';
 
@@ -34,6 +38,7 @@ function sessionSequence(steps: Array<() => Response>) {
 describe('event-based session retry (aws-spec-discovery)', () => {
   beforeEach(() => {
     __resetIdentityMemo();
+    __resetPmakDiagnosticMemo();
   });
 
   it('retries a transient 5xx and resolves later via full-jitter through the injected clock', async () => {
@@ -114,5 +119,21 @@ describe('event-based session retry (aws-spec-discovery)', () => {
     const fetchImpl = vi.fn<typeof fetch>(async () => new Response('down', { status: 503 }));
     const accountType = await resolveTelemetryAccountType('tok', fetchImpl);
     expect(accountType).toBeUndefined();
+  });
+
+  it('shares one normalized-host PMAK diagnostic probe between concurrent callers', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
+      new Response(JSON.stringify({ user: { username: null, email: null } }), {
+        headers: { 'Content-Type': 'application/json' }
+      })
+    );
+
+    const results = await Promise.all([
+      inspectPmakIdentity({ apiBaseUrl: 'https://api.getpostman.com/', apiKey: 'PMAK-cache', fetchImpl }),
+      inspectPmakIdentity({ apiBaseUrl: 'https://api.getpostman.com', apiKey: 'PMAK-cache', fetchImpl })
+    ]);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(results).toEqual([{ kind: 'service-account', status: 200 }, { kind: 'service-account', status: 200 }]);
   });
 });

--- a/tests/no-pmak-asset-or-newman.test.ts
+++ b/tests/no-pmak-asset-or-newman.test.ts
@@ -20,7 +20,8 @@ type PatternId = 'newman' | 'pmak-header' | 'pmak-cli-login';
  * cannot run Collection v3, so only the Postman CLI (`postman collection run`) is allowed.
  */
 const ALLOWLIST: Record<string, PatternId[]> = {
-  'src/lib/postman/token-provider.ts': ['pmak-header']
+  'src/lib/postman/token-provider.ts': ['pmak-header'],
+  'src/lib/postman/pmak-diagnostics.ts': ['pmak-header']
 };
 
 type Violation = { file: string; line: number; pattern: PatternId; text: string };

--- a/tests/release-artifact-contract.test.ts
+++ b/tests/release-artifact-contract.test.ts
@@ -1,0 +1,159 @@
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+// @ts-expect-error JavaScript CLI module exposes its tested pure verifier.
+import { acceptedImmutableTags, validateReleaseArtifacts, verifyNpmIntegrity } from '../scripts/verify-release-artifacts.mjs';
+
+const PACKAGE_NAME = '@postman-cse/onboarding-aws-spec-discovery';
+const REPOSITORY = 'postman-cs/postman-aws-spec-discovery-action';
+const COMMIT_SHA = 'abc123';
+const TAG = 'v3.1.3';
+const VERSION = '3.1.3';
+
+const sha256 = (value: string | Uint8Array) => createHash('sha256').update(value).digest('hex');
+
+function writeTarball(directory: string, packageJson: { name: string; version: string } = {
+  name: PACKAGE_NAME,
+  version: VERSION
+}): void {
+  mkdirSync(join(directory, 'package'));
+  writeFileSync(join(directory, 'package', 'package.json'), JSON.stringify(packageJson));
+  writeFileSync(join(directory, 'package', 'index.js'), 'export {};');
+  execFileSync('tar', ['-czf', join(directory, 'release.tgz'), '-C', directory, 'package']);
+  rmSync(join(directory, 'package'), { recursive: true, force: true });
+}
+
+function writeValidFixture(overrides: Record<string, unknown> = {}, options: {
+  extraFile?: string;
+  packageJson?: { name: string; version: string };
+} = {}): string {
+  const directory = mkdtempSync(join(tmpdir(), 'release-artifacts-'));
+  writeTarball(directory, options.packageJson);
+  if (options.extraFile) writeFileSync(join(directory, options.extraFile), 'extra');
+  writeFileSync(join(directory, 'release-manifest.json'), JSON.stringify({
+    schema_version: 1,
+    repository: REPOSITORY,
+    commit_sha: COMMIT_SHA,
+    tag: TAG,
+    package_name: PACKAGE_NAME,
+    package_version: VERSION,
+    artifacts: [{ path: 'release.tgz', sha256: sha256(readFileSync(join(directory, 'release.tgz'))) }],
+    ...overrides
+  }));
+  return directory;
+}
+
+function validate(directory: string, overrides: Partial<{ repository: string; commitSha: string; tag: string }> = {}) {
+  return validateReleaseArtifacts(directory, {
+    repository: REPOSITORY,
+    commitSha: COMMIT_SHA,
+    tag: TAG,
+    ...overrides
+  });
+}
+
+describe('release artifact verifier', () => {
+  it('accepts a valid allowlisted fixture bound to repository identity', () => {
+    const directory = writeValidFixture();
+    try {
+      expect(() => validate(directory)).not.toThrow();
+      expect(acceptedImmutableTags('3.1.0')).toEqual(['v3.1.0', 'v3.1']);
+      expect(acceptedImmutableTags('3.1.3')).toEqual(['v3.1.3']);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a wrong repository', () => {
+    const directory = writeValidFixture({ repository: 'wrong/repository' });
+    try {
+      expect(() => validate(directory)).toThrow(/repository/);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a wrong SHA', () => {
+    const directory = writeValidFixture({ commit_sha: 'deadbeef' });
+    try {
+      expect(() => validate(directory)).toThrow(/commit_sha/);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a wrong tag', () => {
+    const directory = writeValidFixture({ tag: 'v9.9.9' });
+    try {
+      expect(() => validate(directory)).toThrow(/manifest tag does not match release input/);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a wrong version', () => {
+    const directory = writeValidFixture({ package_version: '9.9.9' });
+    try {
+      expect(() => validate(directory)).toThrow(/tag .* does not match package version/);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a wrong checksum', () => {
+    const directory = writeValidFixture({
+      artifacts: [{ path: 'release.tgz', sha256: '0'.repeat(64) }]
+    });
+    try {
+      expect(() => validate(directory)).toThrow(/checksum/);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a hidden extra', () => {
+    const directory = writeValidFixture({}, { extraFile: '.evil' });
+    try {
+      expect(() => validate(directory)).toThrow(/unexpected release artifact: \.evil/);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an arbitrary package name', () => {
+    const directory = writeValidFixture(
+      { package_name: '@evil/arbitrary-package' },
+      { packageJson: { name: '@evil/arbitrary-package', version: VERSION } }
+    );
+    try {
+      expect(() => validate(directory)).toThrow(/package_name must be @postman-cse\/onboarding-aws-spec-discovery/);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts a valid npm integrity', () => {
+    const directory = writeValidFixture();
+    try {
+      const tarball = join(directory, 'release.tgz');
+      const integrity = `sha512-${createHash('sha512').update(readFileSync(tarball)).digest('base64')}`;
+      expect(verifyNpmIntegrity(tarball, integrity)).toBe(integrity);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a mismatched npm integrity', () => {
+    const directory = writeValidFixture();
+    try {
+      expect(() => verifyNpmIntegrity(join(directory, 'release.tgz'), 'sha512-not-the-staged-tarball')).toThrow(/integrity/);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -1,56 +1,550 @@
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { spawnSync, execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+import { afterEach, describe, expect, it } from 'vitest';
 
-const releaseWorkflow = readFileSync(join(process.cwd(), '.github/workflows/release.yml'), 'utf8');
+// @ts-expect-error JavaScript CLI module exposes its tested pure classifier.
+import { classifyRelease } from '../scripts/classify-release.mjs';
 
-function namedStep(name: string): string {
-  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const match = releaseWorkflow.match(
-    new RegExp(`      - name: ${escapedName}\\n[\\s\\S]*?(?=\\n      - |\\n  [a-zA-Z0-9_-]+:|\\n?$)`)
-  );
+const CHILD_TIMEOUT_MS = 10_000;
+const ALIAS_TEST_TIMEOUT_MS = 30_000;
+const workflowPath = join(process.cwd(), '.github/workflows/release.yml');
+const workflow = readFileSync(workflowPath, 'utf8').replace(/\r\n/g, '\n');
+const policy = readFileSync(join(process.cwd(), 'RELEASE_POLICY.md'), 'utf8');
+const parsed = parse(workflow) as {
+  concurrency: { group: string; 'cancel-in-progress': boolean };
+  jobs: Record<string, Record<string, unknown>>;
+};
+
+const PACKAGE_NAME = '@postman-cse/onboarding-aws-spec-discovery';
+const REPOSITORY = 'postman-cs/postman-aws-spec-discovery-action';
+const COMMIT_SHA = 'abc123';
+const TAG = 'v3.1.3';
+const VERSION = '3.1.3';
+
+function isValidGitExecutable(candidate: string): boolean {
+  try {
+    const version = execFileSync(candidate, ['--version'], {
+      encoding: 'utf8',
+      timeout: CHILD_TIMEOUT_MS,
+      maxBuffer: 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'ignore']
+    });
+    return /^git version /i.test(version);
+  } catch {
+    return false;
+  }
+}
+
+function windowsGitCandidates(): string[] {
+  const candidates: string[] = [];
+  for (const root of [
+    process.env.ProgramFiles,
+    process.env.PROGRAMFILES,
+    process.env['ProgramFiles(x86)'],
+    process.env['PROGRAMFILES(X86)'],
+    process.env.LocalAppData,
+    process.env.LOCALAPPDATA
+  ]) {
+    if (!root) continue;
+    candidates.push(join(root, 'Git', 'cmd', 'git.exe'));
+    candidates.push(join(root, 'Git', 'bin', 'git.exe'));
+  }
+  try {
+    const located = execFileSync('where.exe', ['git'], {
+      encoding: 'utf8',
+      timeout: CHILD_TIMEOUT_MS,
+      maxBuffer: 1024 * 1024
+    });
+    for (const line of located.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (trimmed) candidates.push(trimmed);
+    }
+  } catch {
+    // where.exe returns non-zero when git is not on PATH.
+  }
+  return candidates;
+}
+
+function discoverRealGit(platform = process.platform): string {
+  const candidates =
+    platform === 'win32' ? windowsGitCandidates() : ['/opt/homebrew/bin/git', '/usr/bin/git'];
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    if (seen.has(candidate)) continue;
+    seen.add(candidate);
+    if (!existsSync(candidate)) continue;
+    if (isValidGitExecutable(candidate)) return candidate;
+  }
+  throw new Error('unable to locate a real git binary for temporary alias fixtures');
+}
+
+function fixturePathWithBin(binDir: string, pathValue = process.env.PATH ?? ''): string {
+  return [binDir, pathValue].filter((part) => part.length > 0).join(delimiter);
+}
+
+function windowsGitCmdShim(realGit: string): string {
+  const quoted = `"${realGit.replace(/"/g, '""')}"`;
+  return `@echo off\r\n${quoted} %*\r\n`;
+}
+
+function windowsGitBashShim(realGit: string): string {
+  const escaped = realGit.replace(/'/g, `'\\''`);
+  return `#!/usr/bin/env bash\nexec '${escaped}' "$@"\n`;
+}
+
+function installFixtureGitShim(binDir: string, realGit: string, platform = process.platform): void {
+  if (platform === 'win32') {
+    writeFileSync(join(binDir, 'git.cmd'), windowsGitCmdShim(realGit), { encoding: 'utf8' });
+    // Exact alias body runs under bash; provide an extensionless forwarder bash can exec.
+    writeFileSync(join(binDir, 'git'), windowsGitBashShim(realGit), {
+      encoding: 'utf8',
+      mode: 0o755
+    });
+    return;
+  }
+  symlinkSync(realGit, join(binDir, 'git'));
+}
+
+const REAL_GIT = discoverRealGit();
+
+const temporaryDirectories: string[] = [];
+
+function job(name: string): string {
+  const match = workflow.match(new RegExp(`  ${name}:\\n[\\s\\S]*?(?=\\n  [a-zA-Z0-9_-]+:|$)`));
   return match?.[0] ?? '';
 }
 
-function npmRegistrySetupStep(): string {
-  return releaseWorkflow
-    .match(/ {6}- uses: actions\/setup-node@v\d+\n(?: {8}[^\n]+\n| {10}[^\n]+\n)*/g)
-    ?.find((step) => step.includes("registry-url: 'https://registry.npmjs.org'") && step.includes("if: steps.release_tag.outputs.npm_publish == 'true'")) ?? '';
+function assertOrder(earlier: string, later: string, haystack = workflow): void {
+  expect(haystack.indexOf(earlier)).toBeGreaterThanOrEqual(0);
+  expect(haystack.indexOf(later)).toBeGreaterThanOrEqual(0);
+  expect(haystack.indexOf(earlier)).toBeLessThan(haystack.indexOf(later));
 }
 
-describe('release workflow publishing contract', () => {
-  it('keeps v1 as the only rolling alias and v1.x as a zero-patch publish tag', () => {
-    expect(releaseWorkflow).toContain('PUBLISH_TAGS=("$PKG_VERSION")');
-    expect(releaseWorkflow).toContain('PUBLISH_TAGS+=("$MAJOR.$MINOR")');
-    expect(releaseWorkflow).toContain('if [ "$TAG_VERSION" = "$MAJOR" ]; then');
-    expect(releaseWorkflow).not.toContain('if [ "$TAG_VERSION" = "0" ]; then');
-    expect(releaseWorkflow).toContain('or v$MAJOR');
-    expect(releaseWorkflow).toContain('echo "npm_publish=true" >> "$GITHUB_OUTPUT"');
-    expect(releaseWorkflow).toContain('echo "npm_publish=false" >> "$GITHUB_OUTPUT"');
-    expect(releaseWorkflow).toContain('skipping npm publish');
-    expect(releaseWorkflow).not.toContain('ALIAS_TAGS');
-    expect(releaseWorkflow).not.toContain('publish_tag');
+function sha256(value: string | Uint8Array): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function extractInlineVerifierBody(): string {
+  const match = workflow.match(
+    /name: Verify release artifacts\n\s+run: \|\n\s+node --input-type=module <<'NODE'\n([\s\S]*?)\n(\s+)NODE\n/
+  );
+  expect(match?.[1]).toBeTruthy();
+  const indent = match?.[2] ?? '';
+  return (match?.[1] ?? '')
+    .split('\n')
+    .map((line) => (indent && line.startsWith(indent) ? line.slice(indent.length) : line))
+    .join('\n');
+}
+
+function extractAliasShellBody(): string {
+  const match = workflow.match(
+    /name: Advance rolling major alias monotonically\n\s+run: \|\n([\s\S]*)$/
+  );
+  expect(match?.[1]).toBeTruthy();
+  const lines = (match?.[1] ?? '').replace(/\n+$/, '').split('\n');
+  const indentMatch = lines[0]?.match(/^(\s*)/);
+  const indent = indentMatch?.[1] ?? '';
+  return lines.map((line) => (indent && line.startsWith(indent) ? line.slice(indent.length) : line)).join('\n');
+}
+
+function fixtureGitEnv(binDir: string, hooksDir: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    PATH: fixturePathWithBin(binDir),
+    GIT_CONFIG_COUNT: '1',
+    GIT_CONFIG_KEY_0: 'core.hooksPath',
+    GIT_CONFIG_VALUE_0: hooksDir
+  };
+  // Temporary fixtures must use real git; clear shell-guard injection for non-interactive bash.
+  delete env.BASH_ENV;
+  delete env.ENV;
+  return env;
+}
+
+function git(cwd: string, args: readonly string[], binDir: string, hooksDir: string): string {
+  return execFileSync(REAL_GIT, args, {
+    cwd,
+    encoding: 'utf8',
+    timeout: CHILD_TIMEOUT_MS,
+    maxBuffer: 1024 * 1024,
+    env: fixtureGitEnv(binDir, hooksDir)
+  }).trim();
+}
+
+function writePackageJson(directory: string, version: string): void {
+  writeFileSync(join(directory, 'package.json'), `${JSON.stringify({ name: PACKAGE_NAME, version }, null, 2)}\n`);
+}
+
+function createAliasFixture(options: {
+  currentVersion: string;
+  candidateVersion: string;
+}): {
+  root: string;
+  work: string;
+  remote: string;
+  binDir: string;
+  hooksDir: string;
+  currentSha: string;
+  candidateSha: string;
+} {
+  const root = mkdtempSync(join(tmpdir(), 'alias-shell-'));
+  temporaryDirectories.push(root);
+  const remote = join(root, 'remote.git');
+  const work = join(root, 'work');
+  const binDir = join(root, 'bin');
+  const hooksDir = join(root, 'hooks');
+  mkdirSync(remote);
+  mkdirSync(work);
+  mkdirSync(binDir);
+  mkdirSync(hooksDir);
+  installFixtureGitShim(binDir, REAL_GIT);
+
+  execFileSync(REAL_GIT, ['init', '--bare', '-b', 'main', remote], {
+    timeout: CHILD_TIMEOUT_MS,
+    maxBuffer: 1024 * 1024,
+    env: fixtureGitEnv(binDir, hooksDir)
+  });
+  execFileSync(REAL_GIT, ['init', '-b', 'main', work], {
+    timeout: CHILD_TIMEOUT_MS,
+    maxBuffer: 1024 * 1024,
+    env: fixtureGitEnv(binDir, hooksDir)
+  });
+  git(work, ['config', 'user.name', 'alias-fixture'], binDir, hooksDir);
+  git(work, ['config', 'user.email', 'alias-fixture@example.com'], binDir, hooksDir);
+  git(work, ['remote', 'add', 'origin', remote], binDir, hooksDir);
+
+  writePackageJson(work, options.currentVersion);
+  writeFileSync(join(work, 'README.md'), 'current\n');
+  git(work, ['add', 'package.json', 'README.md'], binDir, hooksDir);
+  git(work, ['commit', '-m', 'current alias target'], binDir, hooksDir);
+  const currentSha = git(work, ['rev-parse', 'HEAD'], binDir, hooksDir);
+  git(work, ['tag', '-a', 'v3', '-m', 'Rolling v3 alias', currentSha], binDir, hooksDir);
+  git(work, ['push', 'origin', 'HEAD:main', 'refs/tags/v3'], binDir, hooksDir);
+
+  writePackageJson(work, options.candidateVersion);
+  writeFileSync(join(work, 'README.md'), 'candidate\n');
+  git(work, ['add', 'package.json', 'README.md'], binDir, hooksDir);
+  git(work, ['commit', '-m', 'candidate release'], binDir, hooksDir);
+  const candidateSha = git(work, ['rev-parse', 'HEAD'], binDir, hooksDir);
+  expect(candidateSha).not.toBe(currentSha);
+  git(work, ['push', 'origin', 'HEAD:main'], binDir, hooksDir);
+
+  return { root, work, remote, binDir, hooksDir, currentSha, candidateSha };
+}
+
+function runAliasShell(
+  cwd: string,
+  binDir: string,
+  hooksDir: string,
+  env: { GITHUB_SHA: string; GITHUB_REF_NAME: string }
+): ReturnType<typeof spawnSync> {
+  return spawnSync('bash', ['-c', extractAliasShellBody()], {
+    cwd,
+    encoding: 'utf8',
+    timeout: CHILD_TIMEOUT_MS,
+    maxBuffer: 1024 * 1024,
+    env: {
+      ...fixtureGitEnv(binDir, hooksDir),
+      GITHUB_SHA: env.GITHUB_SHA,
+      GITHUB_REF_NAME: env.GITHUB_REF_NAME
+    }
+  });
+}
+
+function remoteAliasCommit(remote: string, binDir: string, hooksDir: string): string {
+  return execFileSync(REAL_GIT, ['--git-dir', remote, 'rev-parse', 'refs/tags/v3^{}'], {
+    encoding: 'utf8',
+    timeout: CHILD_TIMEOUT_MS,
+    maxBuffer: 1024 * 1024,
+    env: fixtureGitEnv(binDir, hooksDir)
+  }).trim();
+}
+
+function writeReleaseArtifactsFixture(root: string, options: { extraFile?: string } = {}): string {
+  const directory = join(root, 'release-artifacts');
+  mkdirSync(directory, { recursive: true });
+  const packageDirectory = join(directory, 'package');
+  mkdirSync(packageDirectory);
+  writeFileSync(join(packageDirectory, 'package.json'), JSON.stringify({ name: PACKAGE_NAME, version: VERSION }));
+  writeFileSync(join(packageDirectory, 'index.js'), 'export {};\n');
+  execFileSync('tar', ['-czf', join(directory, 'release.tgz'), '-C', directory, 'package'], {
+    timeout: CHILD_TIMEOUT_MS
+  });
+  rmSync(packageDirectory, { recursive: true, force: true });
+  if (options.extraFile) writeFileSync(join(directory, options.extraFile), 'extra');
+  writeFileSync(
+    join(directory, 'release-manifest.json'),
+    JSON.stringify({
+      schema_version: 1,
+      repository: REPOSITORY,
+      commit_sha: COMMIT_SHA,
+      tag: TAG,
+      package_name: PACKAGE_NAME,
+      package_version: VERSION,
+      artifacts: [{ path: 'release.tgz', sha256: sha256(readFileSync(join(directory, 'release.tgz'))) }]
+    })
+  );
+  return directory;
+}
+
+function runInlineVerifier(root: string) {
+  return spawnSync(process.execPath, ['--input-type=module'], {
+    cwd: root,
+    encoding: 'utf8',
+    input: extractInlineVerifierBody(),
+    timeout: CHILD_TIMEOUT_MS,
+    maxBuffer: 1024 * 1024,
+    env: {
+      ...process.env,
+      GITHUB_REPOSITORY: REPOSITORY,
+      GITHUB_SHA: COMMIT_SHA,
+      GITHUB_REF_NAME: TAG
+    }
+  });
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('release workflow contract', () => {
+  it('classifies with the exported script before install and keeps zero-patch immutable publish tags with major alias no-op', () => {
+    const classify = job('classify');
+    expect(classify).toContain('name: Classify release tag');
+    expect(classify).toContain('node scripts/classify-release.mjs');
+    expect(classify).not.toContain('npm ci');
+    assertOrder('node scripts/classify-release.mjs', '- run: npm ci');
+
+    expect(classifyRelease({ ref: 'refs/tags/v3.1.3', refName: 'v3.1.3', packageVersion: '3.1.3' })).toEqual({
+      release_kind: 'immutable',
+      npm_publish: 'true'
+    });
+    expect(classifyRelease({ ref: 'refs/tags/v3.1', refName: 'v3.1', packageVersion: '3.1.0' })).toEqual({
+      release_kind: 'immutable',
+      npm_publish: 'true'
+    });
+    expect(classifyRelease({ ref: 'refs/tags/v3', refName: 'v3', packageVersion: '3.1.3' })).toEqual({
+      release_kind: 'alias',
+      npm_publish: 'false'
+    });
+    expect(() =>
+      classifyRelease({ ref: 'refs/heads/main', refName: 'main', packageVersion: '3.1.3' })
+    ).toThrow(/got refs\/heads\/main; expected v3\.1\.3, v3\.1 when patch is zero, or v3/);
+    expect(() =>
+      classifyRelease({ ref: 'refs/tags/v3.1.2', refName: 'v3.1.2', packageVersion: '3.1.3' })
+    ).toThrow(/got v3\.1\.2; expected v3\.1\.3, v3\.1 when patch is zero, or v3/);
+
+    expect(policy).toContain('When the package patch is `0`');
+    expect(policy).toContain('`vMAJOR.MINOR`');
+    expect(policy).toContain('MAJOR.MINOR.0');
+    expect(policy).toContain('rolling major alias');
+    expect(policy).toContain('versions that match exact immutable GitHub release tags');
+    expect(policy).toContain('zero-patch minor immutable tags (`vMAJOR.MINOR`) map to package version `MAJOR.MINOR.0`');
   });
 
-  it('keeps GitHub release artifacts while making npm publication idempotent', () => {
-    expect(namedStep('Publish GitHub release')).not.toMatch(/\n\s+if:/);
-    expect(npmRegistrySetupStep()).toContain("if: steps.release_tag.outputs.npm_publish == 'true'");
-    expect(namedStep('Check npm package version')).toContain('id: npm_package');
-    expect(namedStep('Check npm package version')).toContain('npm view "$PKG_NAME@$PKG_VERSION" version');
-    expect(namedStep('Check npm package version')).toContain('already_published=true');
-    expect(namedStep('Publish to npm')).toContain("if: steps.release_tag.outputs.npm_publish == 'true' && steps.npm_package.outputs.already_published != 'true'");
-    expect(namedStep('Attach npm tarball to release')).not.toMatch(/\n\s+if:/);
-    expect(namedStep('Upload tarball')).not.toMatch(/\n\s+if:/);
+  it('gates every post-classifier job on immutable release_kind only', () => {
+    for (const name of ['verify-package', 'publish', 'advance-major-alias'] as const) {
+      const body = job(name);
+      expect(body).toContain("if: ${{ needs.classify.outputs.release_kind == 'immutable' }}");
+      expect(parsed.jobs[name].if).toBe("${{ needs.classify.outputs.release_kind == 'immutable' }}");
+    }
+    expect(workflow.match(/needs\.classify\.outputs\.release_kind == 'immutable'/g) ?? []).toHaveLength(3);
   });
 
-  it('advances the rolling major alias after an immutable release publishes', () => {
-    expect(releaseWorkflow).toContain('advance-major-alias:');
-    expect(releaseWorkflow).toContain('needs: release');
-    expect(releaseWorkflow).toContain("if: ${{ needs.release.outputs.npm_publish == 'true' }}");
-    expect(releaseWorkflow).toContain('npm_publish: ${{ steps.release_tag.outputs.npm_publish }}');
-    expect(namedStep('Force-move rolling major alias tag')).toContain('git tag -fa "$MAJOR"');
-    expect(namedStep('Force-move rolling major alias tag')).toContain('git push origin "$MAJOR" --force');
-    expect(namedStep('Force-move rolling major alias tag')).toContain('COMMIT="$(git rev-parse "HEAD^{commit}")"');
+  it('uses exact permissions, one bundle, and the exact gate set with ACTIONLINT_BIN', () => {
+    const verify = job('verify-package');
+    expect(verify).toMatch(/permissions:\n {6}contents: read/);
+    expect(verify).not.toContain('NPM_TOKEN');
+    expect(verify).not.toContain('id-token: write');
+    expect(verify).toContain('ACTIONLINT_BIN="$RUNNER_TEMP/actionlint"');
+    expect(verify).toContain('"$ACTIONLINT_BIN" -version');
+    expect(verify).toContain('echo "ACTIONLINT_BIN=$ACTIONLINT_BIN" >> "$GITHUB_ENV"');
+    expect(verify).toContain('download-actionlint.bash) 1.7.11 "$RUNNER_TEMP"');
+    expect(verify).toContain('MAX_PARALLEL_GATES=2');
+    expect(verify).toContain('run lint npm run lint');
+    expect(verify).toContain('run typecheck npm run typecheck');
+    expect(verify).toContain('run test npm test');
+    expect(verify).toContain('run dist npm run verify:dist:assert');
+    expect(verify).toContain('run actionlint "$ACTIONLINT_BIN"');
+    assertOrder('- run: npm run bundle', 'name: Run gates', verify);
+    expect((verify.match(/npm run bundle/g) ?? []).length).toBe(1);
+    expect(workflow).not.toContain('actions/setup-go');
+    expect(workflow).not.toContain('go install github.com/rhysd/actionlint');
   });
+
+  it('stages only the allowlisted artifact pair, verifies before upload, and names by run identity', () => {
+    const verify = job('verify-package');
+    expect(verify).toContain('mkdir release-stage');
+    expect(verify).toContain('npm pack --pack-destination release-stage');
+    expect(verify).toContain('release-stage/release.tgz');
+    expect(verify).toContain('release-stage/release-manifest.json');
+    expect(verify).toContain('node scripts/verify-release-artifacts.mjs release-stage');
+    expect(verify).toContain('name: release-${{ github.run_id }}-${{ github.run_attempt }}');
+    assertOrder('node scripts/verify-release-artifacts.mjs release-stage', 'actions/upload-artifact@v7', verify);
+    expect(verify).toContain('release-stage/release.tgz');
+    expect(verify).toContain('release-stage/release-manifest.json');
+  });
+
+  it('keeps an artifact-only publisher with inline identity checks and no repository source download', () => {
+    const publish = job('publish');
+    expect(publish).toMatch(/permissions:\n {6}contents: write\n {6}id-token: write/);
+    expect(publish).toContain('actions/download-artifact@v8');
+    expect(publish).toContain('name: release-${{ github.run_id }}-${{ github.run_attempt }}');
+    expect(publish).not.toContain('actions/checkout');
+    expect(publish).not.toContain('npm ci');
+    expect(publish).not.toContain('cache:');
+    expect(publish).not.toMatch(/\bnpm pack\b/);
+    expect(publish).not.toContain('npm run bundle');
+    expect(publish).not.toMatch(/\bcurl\b/);
+    expect(publish).not.toContain('Download immutable artifact verifier');
+    expect(publish).not.toContain('raw/$GITHUB_SHA/scripts/verify-release-artifacts.mjs');
+    expect(publish).toContain("const expectedPackageName = '@postman-cse/onboarding-aws-spec-discovery'");
+    expect(publish).toContain("new Set(['release.tgz', 'release-manifest.json'])");
+    expect(publish).toContain("execFileSync('tar', ['-xOf', tarballPath, 'package/package.json']");
+    assertOrder('name: Verify release artifacts', 'name: Publish or verify npm package', publish);
+    assertOrder('name: Publish or verify npm package', 'name: Publish GitHub release', publish);
+  });
+
+  it('executes the exact inline privileged verifier against accept and unexpected-artifact fixtures', () => {
+    const root = mkdtempSync(join(tmpdir(), 'inline-verifier-'));
+    temporaryDirectories.push(root);
+    writeReleaseArtifactsFixture(root);
+
+    const accepted = runInlineVerifier(root);
+    expect(accepted.error).toBeUndefined();
+    expect(accepted.status).toBe(0);
+
+    writeFileSync(join(root, 'release-artifacts', '.evil'), 'extra');
+    const rejected = runInlineVerifier(root);
+    expect(rejected.error).toBeUndefined();
+    expect(rejected.status).not.toBe(0);
+    expect(rejected.status).toBeGreaterThan(0);
+    expect(`${rejected.stderr}${rejected.stdout}`).toMatch(/unexpected release artifact: \.evil/);
+  });
+
+  it('builds portable fixture PATH and Windows git shims without shell or ln', () => {
+    expect(delimiter).toBe(process.platform === 'win32' ? ';' : ':');
+    expect(fixturePathWithBin('C:\\fixture\\bin', 'C:\\existing\\bin')).toBe(
+      ['C:\\fixture\\bin', 'C:\\existing\\bin'].join(delimiter)
+    );
+    expect(fixturePathWithBin('/fixture/bin', '/existing/bin')).toBe(
+      ['/fixture/bin', '/existing/bin'].join(delimiter)
+    );
+    expect(fixturePathWithBin('/fixture/bin')).toContain(delimiter);
+
+    expect(windowsGitCmdShim('C:\\Program Files\\Git\\cmd\\git.exe')).toBe(
+      '@echo off\r\n"C:\\Program Files\\Git\\cmd\\git.exe" %*\r\n'
+    );
+    expect(windowsGitCmdShim('C:\\path\\with"quote\\git.exe')).toBe(
+      '@echo off\r\n"C:\\path\\with""quote\\git.exe" %*\r\n'
+    );
+    expect(windowsGitBashShim('C:\\Program Files\\Git\\cmd\\git.exe')).toBe(
+      `#!/usr/bin/env bash\nexec 'C:\\Program Files\\Git\\cmd\\git.exe' "$@"\n`
+    );
+    expect(windowsGitBashShim("C:\\path\\with'quote\\git.exe")).toBe(
+      `#!/usr/bin/env bash\nexec 'C:\\path\\with'\\''quote\\git.exe' "$@"\n`
+    );
+
+    const root = mkdtempSync(join(tmpdir(), 'alias-shim-'));
+    temporaryDirectories.push(root);
+    const winBin = join(root, 'win-bin');
+    mkdirSync(winBin);
+    installFixtureGitShim(winBin, REAL_GIT, 'win32');
+    expect(readFileSync(join(winBin, 'git.cmd'), 'utf8')).toBe(windowsGitCmdShim(REAL_GIT));
+    expect(readFileSync(join(winBin, 'git'), 'utf8')).toBe(windowsGitBashShim(REAL_GIT));
+
+    if (process.platform !== 'win32') {
+      const posixBin = join(root, 'posix-bin');
+      mkdirSync(posixBin);
+      installFixtureGitShim(posixBin, REAL_GIT, 'linux');
+      expect(existsSync(join(posixBin, 'git'))).toBe(true);
+      expect(existsSync(join(posixBin, 'git.cmd'))).toBe(false);
+    }
+
+    expect(isValidGitExecutable(REAL_GIT)).toBe(true);
+    expect(discoverRealGit()).toBe(REAL_GIT);
+  });
+
+  it('computes Node SHA-512 SRI, publishes npm before GitHub, then advances the major alias monotonically', () => {
+    const publish = job('publish');
+    const alias = job('advance-major-alias');
+    expect(publish).toContain("createHash('sha512').update(readFileSync('release-artifacts/release.tgz')).digest('base64')");
+    expect(publish).not.toContain('openssl dgst');
+    expect(publish).not.toContain('| base64');
+    expect(publish).toContain('npm view "$PACKAGE_NAME@$PACKAGE_VERSION" dist.integrity');
+    expect(publish).toContain('npm publish ./release-artifacts/release.tgz --provenance --access public');
+    assertOrder('npm publish ./release-artifacts/release.tgz --provenance --access public', 'softprops/action-gh-release', publish);
+    assertOrder('  publish:', '  advance-major-alias:');
+    expect(alias).toContain('fetch-depth: 1');
+    expect(alias).toContain('git fetch --tags --force');
+    expect(alias).toContain('VERSION="$(node -p "require(\'./package.json\').version")"');
+    expect(alias).not.toContain('VERSION="${GITHUB_REF_NAME#v}"');
+    expect(alias).toContain('CANDIDATE="$GITHUB_SHA"');
+    expect(alias).toContain('git show "$MAJOR^{}:package.json"');
+    expect(alias).toContain('Not moving $MAJOR backward');
+    expect(alias).toContain('sort -V');
+    expect(alias).toContain('git push origin "$MAJOR" --force');
+    expect(parsed.concurrency).toEqual({
+      group: 'release-${{ github.repository }}',
+      'cancel-in-progress': false
+    });
+  });
+
+  it(
+    'moves the major alias for a zero-patch same-version candidate when triggered as vMAJOR.MINOR',
+    () => {
+      const { work, remote, binDir, hooksDir, candidateSha } = createAliasFixture({
+        currentVersion: '3.1.0',
+        candidateVersion: '3.1.0'
+      });
+      expect(remoteAliasCommit(remote, binDir, hooksDir)).not.toBe(candidateSha);
+
+      const result = runAliasShell(work, binDir, hooksDir, {
+        GITHUB_SHA: candidateSha,
+        GITHUB_REF_NAME: 'v3.1'
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(remoteAliasCommit(remote, binDir, hooksDir)).toBe(candidateSha);
+    },
+    ALIAS_TEST_TIMEOUT_MS
+  );
+
+  it(
+    'keeps the major alias when the candidate package version is older than the current alias target',
+    () => {
+      const { work, remote, binDir, hooksDir, currentSha, candidateSha } = createAliasFixture({
+        currentVersion: '3.2.0',
+        candidateVersion: '3.1.0'
+      });
+      expect(remoteAliasCommit(remote, binDir, hooksDir)).toBe(currentSha);
+
+      const result = runAliasShell(work, binDir, hooksDir, {
+        GITHUB_SHA: candidateSha,
+        GITHUB_REF_NAME: 'v3.1'
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(`${result.stdout}${result.stderr}`).toContain(
+        '::notice::Not moving v3 backward from 3.2.0 to 3.1.0'
+      );
+      expect(remoteAliasCommit(remote, binDir, hooksDir)).toBe(currentSha);
+    },
+    ALIAS_TEST_TIMEOUT_MS
+  );
 });

--- a/tests/telemetry-account-type.test.ts
+++ b/tests/telemetry-account-type.test.ts
@@ -4,9 +4,13 @@ import {
   __resetIdentityMemo,
   resolveTelemetryAccountType
 } from '../src/lib/postman/credential-identity.js';
+import { __resetPmakDiagnosticMemo } from '../src/lib/postman/pmak-diagnostics.js';
 import { prepareTelemetryCredentials } from '../src/lib/postman/telemetry-credentials.js';
 
-beforeEach(() => __resetIdentityMemo());
+beforeEach(() => {
+  __resetIdentityMemo();
+  __resetPmakDiagnosticMemo();
+});
 afterEach(() => vi.restoreAllMocks());
 
 describe('resolveTelemetryAccountType (aws-spec-discovery telemetry enrichment)', () => {
@@ -82,4 +86,84 @@ describe('prepareTelemetryCredentials', () => {
       provider: expect.objectContaining({ current: expect.any(Function) })
     });
   });
+
+  it('classifies a rejected mint once, masks the PMAK, and skips account-type enrichment', async () => {
+    const apiKey = 'PMAK-diagnostic-sentinel';
+    const onWarning = vi.fn();
+    const fetchImpl = vi.fn<typeof fetch>(async (url, init) => {
+      if (String(url).endsWith('/service-account-tokens')) {
+        expect(init?.method).toBe('POST');
+        return new Response('rejected', { status: 401 });
+      }
+      if (String(url).endsWith('/me')) {
+        expect(init).toEqual(
+          expect.objectContaining({
+            method: 'GET',
+            headers: { 'x-api-key': apiKey }
+          })
+        );
+        return new Response(
+          JSON.stringify({ user: { username: 'jane-doe', email: 'jane@example.com' } }),
+          { headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      throw new Error(`unexpected fetch: ${String(url)}`);
+    });
+
+    const result = await prepareTelemetryCredentials({ postmanApiKey: apiKey, fetchImpl, onWarning });
+
+    expect(result.accountType).toBeUndefined();
+    expect(onWarning).toHaveBeenCalledTimes(1);
+    expect(onWarning).toHaveBeenCalledWith(
+      expect.stringContaining('Personal API key detected, cannot mint a service-account access token')
+    );
+    expect(onWarning.mock.calls[0][0]).not.toContain(apiKey);
+    expect(onWarning.mock.calls[0][0]).not.toContain('jane-doe');
+    expect(onWarning.mock.calls[0][0]).not.toContain('jane@example.com');
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    [403, { user: { username: null, email: null } }, 'lacks permission to mint access tokens'],
+    [401, undefined, 'postman-api-key is invalid, disabled, or expired'],
+    [403, undefined, 'postman-api-key is invalid, disabled, or expired'],
+    [401, { user: {} }, 'postman: re-mint failed because the postman-api-key was rejected']
+  ] as const)(
+    'warns once and leaves account_type unset for mint HTTP %i diagnostic outcomes',
+    async (mintStatus, mePayload, expectedWarning) => {
+      const apiKey = `PMAK-${mintStatus}-${expectedWarning.length}`;
+      const onWarning = vi.fn();
+      const fetchImpl = vi.fn<typeof fetch>(async (url, init) => {
+        if (String(url).endsWith('/service-account-tokens')) {
+          return new Response('rejected', { status: mintStatus });
+        }
+        if (String(url).endsWith('/me')) {
+          expect(init).toEqual({
+            method: 'GET',
+            headers: { 'x-api-key': apiKey },
+            signal: expect.any(AbortSignal)
+          });
+          return mePayload === undefined
+            ? new Response('', { status: mintStatus })
+            : new Response(JSON.stringify(mePayload), {
+                headers: { 'Content-Type': 'application/json' }
+              });
+        }
+        throw new Error(`unexpected fetch: ${String(url)}`);
+      });
+
+      const result = await prepareTelemetryCredentials({ postmanApiKey: apiKey, fetchImpl, onWarning });
+
+      expect(result.accountType).toBeUndefined();
+      expect(onWarning).toHaveBeenCalledTimes(1);
+      expect(onWarning.mock.calls[0][0]).toMatch(
+        new RegExp(`^postman: telemetry credential enrichment failed\\. .*${expectedWarning}`)
+      );
+      expect(onWarning.mock.calls[0][0]).not.toContain(apiKey);
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(fetchImpl.mock.calls.map(([url]) => String(url))).not.toContain(
+        'https://iapub.postman.co/api/sessions/current'
+      );
+    }
+  );
 });


### PR DESCRIPTION
## Summary

Rejected service-token mints previously lost the PMAK identity context operators need to distinguish an expired key from a team or account mismatch. AWS discovery now performs bounded PMAK diagnosis, preserves actionable status guidance, and ships through an immutable artifact release path.

## What changed

- Adds read-only PMAK identity diagnostics around mint failures without moving AWS discovery asset work onto PMAK.
- Preserves account-type telemetry behavior while avoiding duplicate or fallback token operations.
- Builds the npm package in an unprivileged job, records its identity and checksum in a manifest, and verifies the exact bytes before publication.
- Separates immutable tag publication from rolling alias handling and refuses alias regression.

## Safety

- PMAK diagnosis is bounded to `GET /me`; it doesn't become an asset API fallback.
- The publish job consumes only the staged artifact and rejects repository, commit, tag, package, or checksum mismatches.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run verify:dist:assert`
