### PR TITLE
perf(ci): accelerate Windows parity gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - run: npm ci
       - name: Install actionlint
         run: |
-          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.11 "$RUNNER_TEMP"
+          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/393031adb9afb225ee52ae2ccd7a5af5525e03e8/scripts/download-actionlint.bash) 1.7.11 "$RUNNER_TEMP"
           ACTIONLINT_BIN="$RUNNER_TEMP/actionlint"
           "$ACTIONLINT_BIN" -version
           echo "ACTIONLINT_BIN=$ACTIONLINT_BIN" >> "$GITHUB_ENV"
@@ -103,49 +103,12 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: '24'
-          cache: npm
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
-      - run: npm run bundle
-      - name: Run gates
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $maxParallelGates = 2
-          $checks = @(
-            @{ Name = 'lint'; Args = @('run', 'lint') },
-            @{ Name = 'test'; Args = @('test') },
-            @{ Name = 'typecheck'; Args = @('run', 'typecheck') },
-            @{ Name = 'dist'; Args = @('run', 'verify:dist:assert') }
-          )
-          $jobs = @()
-          $results = @{}
-          foreach ($check in $checks) {
-            while ($jobs.Count -ge $maxParallelGates) {
-              $finished = Wait-Job -Job $jobs -Any
-              Write-Output "::group::$($finished.Name)"
-              Receive-Job -Job $finished -ErrorAction Continue 2>&1 | Write-Output
-              Write-Output "::endgroup::"
-              $results[$finished.Name] = if ($finished.State -eq 'Completed') { 0 } else { 1 }
-              Remove-Job -Job $finished
-              $jobs = @($jobs | Where-Object Id -ne $finished.Id)
-            }
-            $jobs += Start-Job -Name $check.Name -ScriptBlock {
-              param($npmArgs)
-              & npm @npmArgs
-              if ($LASTEXITCODE -ne 0) { throw "gate failed with exit code $LASTEXITCODE" }
-            } -ArgumentList (,$check.Args)
-          }
-          foreach ($job in $jobs) {
-            Wait-Job -Job $job | Out-Null
-            Write-Output "::group::$($job.Name)"
-            Receive-Job -Job $job -ErrorAction Continue 2>&1 | Write-Output
-            Write-Output "::endgroup::"
-            $results[$job.Name] = if ($job.State -eq 'Completed') { 0 } else { 1 }
-            Remove-Job -Job $job
-          }
-          $failed = $false
-          foreach ($check in $checks) {
-            if ($results[$check.Name] -eq 0) { Write-Output "gate:$($check.Name)=pass" } else { Write-Output "gate:$($check.Name)=fail"; $failed = $true }
-          }
-          if ($failed) { exit 1 }
+      - id: windows-node-modules
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: node_modules
+          key: Windows/node-24/exact-${{ hashFiles('package-lock.json') }}
+      - if: steps.windows-node-modules.outputs.cache-hit != 'true'
+        run: npm ci --prefer-offline --no-audit --no-fund
+      - run: npm test

--- a/tests/ci-workflow.test.ts
+++ b/tests/ci-workflow.test.ts
@@ -1,7 +1,5 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { spawnSync } from 'node:child_process';
 
 import { describe, expect, it } from 'vitest';
 
@@ -29,24 +27,19 @@ function linuxQueuedGates(runGates: string): string[] {
   return [...runGates.matchAll(/^\s+run ([a-zA-Z0-9_-]+)\s+/gm)].map((m) => m[1]!);
 }
 
-/** Exact Windows `Run gates` PowerShell body under `run: |`, with YAML indent stripped. */
-function extractWindowsRunGatesBody(source: string): string {
-  const windows = jobText(source, 'windows');
-  const match = windows.match(/ {6}- name: Run gates\n {8}shell: pwsh\n {8}run: \|\n([\s\S]*)$/);
-  if (!match?.[1]) {
-    throw new Error('Windows Run gates pwsh body not found');
-  }
-  return match[1]
-    .replace(/\n$/, '')
-    .split('\n')
-    .map((line) => (line.startsWith('          ') ? line.slice(10) : line))
-    .join('\n');
-}
-
 const linux = jobText(workflow, 'gate');
 const windows = jobText(workflow, 'windows');
 
 describe('CI workflow contract', () => {
+  it('keeps independent Linux/Windows jobs with no needs edges', () => {
+    const jobsSection = workflow.slice(workflow.indexOf('\njobs:\n'));
+    const jobMatches = jobsSection.match(/^ {2}[a-zA-Z0-9_-]+:$/gm) ?? [];
+    expect(jobMatches).toEqual(['  gate:', '  windows:']);
+    expect(linux).not.toMatch(/^\s*needs:/m);
+    expect(windows).not.toMatch(/^\s*needs:/m);
+    expect(workflow).not.toMatch(/^\s*needs:/m);
+  });
+
   it('supersedes PRs only and bundles once before bounded Linux gates', () => {
     expect(workflow).toContain('group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}');
     expect(workflow).toContain("cancel-in-progress: ${{ github.event_name == 'pull_request' }}");
@@ -85,105 +78,93 @@ describe('CI workflow contract', () => {
   });
 
   it('pins actionlint 1.7.11 at $RUNNER_TEMP/actionlint with PR-only commitlint history', () => {
+    const ACTIONLINT_DOWNLOADER_COMMIT = '393031adb9afb225ee52ae2ccd7a5af5525e03e8';
     const install = namedStep(linux, 'Install actionlint');
+    expect(ACTIONLINT_DOWNLOADER_COMMIT).toHaveLength(40);
+    expect(install).toContain(
+      `https://raw.githubusercontent.com/rhysd/actionlint/${ACTIONLINT_DOWNLOADER_COMMIT}/scripts/download-actionlint.bash`,
+    );
+    expect(install.match(/393031adb9afb225ee52ae2ccd7a5af5525e03e8/)?.[0]).toHaveLength(40);
     expect(install).toContain('download-actionlint.bash) 1.7.11 "$RUNNER_TEMP"');
+    expect(install).not.toContain('/main/scripts');
+    expect(workflow).not.toContain('/main/scripts/download-actionlint.bash');
     expect(install).toContain('ACTIONLINT_BIN="$RUNNER_TEMP/actionlint"');
+    expect(install).toContain('"$ACTIONLINT_BIN" -version');
+    expect(install).toContain('echo "ACTIONLINT_BIN=$ACTIONLINT_BIN" >> "$GITHUB_ENV"');
     expect(workflow).not.toContain('actions/setup-go');
     expect(workflow).not.toContain('go install github.com/rhysd/actionlint');
 
     expect(linux).toContain('fetch-depth: 0');
     expect(windows).not.toMatch(/^\s*fetch-depth:\s*/m);
     expect(windows).not.toContain('commitlint');
+    expect(windows).not.toContain('actionlint');
   });
 
-  it('preserves Windows coverage with a bundle-once bounded queue and native exit propagation', () => {
+  it('preserves the current no-NPM-token policy on both jobs', () => {
+    expect(workflow).not.toMatch(/NODE_AUTH_TOKEN\s*:/);
+    expect(workflow).not.toContain('secrets.NPM_TOKEN');
+    expect(workflow).not.toContain('NPM_TOKEN');
+  });
+
+  it('caches Windows node_modules with pinned actions/cache and cache-miss-only install', () => {
+    expect(windows).toContain('name: Windows gate');
     expect(windows).toContain('runs-on: windows-latest');
-    expect(windows.match(/^\s*- run: npm run bundle\s*$/gm) ?? []).toHaveLength(1);
-    expect(windows.indexOf('- run: npm run bundle')).toBeLessThan(windows.indexOf('- name: Run gates'));
+    expect(windows).toContain("node-version: '24'");
+    expect(windows).not.toMatch(/^\s*cache:\s*npm\s*$/m);
 
-    const runGates = namedStep(windows, 'Run gates');
-    expect(runGates).toContain('shell: pwsh');
-    expect(runGates).toContain("$ErrorActionPreference = 'Stop'");
-    expect(runGates).toContain('$maxParallelGates = 2');
-    expect(runGates).toContain('while ($jobs.Count -ge $maxParallelGates)');
-    expect(runGates).toContain('Start-Job');
+    expect(windows).toContain('id: windows-node-modules');
+    expect(windows).toContain('uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0');
+    expect(windows).toContain('path: node_modules');
+    expect(windows).toContain("key: Windows/node-24/exact-${{ hashFiles('package-lock.json') }}");
+    expect(windows).not.toContain('restore-keys');
+    expect(windows).not.toContain('restore-key');
+    expect(windows).not.toContain('enableCrossOsArchive');
 
-    expect(runGates).toContain("@{ Name = 'lint'; Args = @('run', 'lint') }");
-    expect(runGates).toContain("@{ Name = 'test'; Args = @('test') }");
-    expect(runGates).toContain("@{ Name = 'typecheck'; Args = @('run', 'typecheck') }");
-    expect(runGates).toContain("@{ Name = 'dist'; Args = @('run', 'verify:dist:assert') }");
-    expect(runGates.match(/@\{ Name = '[^']+'; Args = @[^}]+\}/g) ?? []).toHaveLength(4);
-
-    expect(runGates).not.toContain('Invoke-Expression');
-    expect(runGates).toContain('& npm @npmArgs');
-    expect(runGates).toContain('if ($LASTEXITCODE -ne 0) { throw "gate failed with exit code $LASTEXITCODE" }');
-    expect(runGates).toContain('-ArgumentList (,$check.Args)');
-    expect(runGates.match(/Receive-Job -Job \$[^ ]+ -ErrorAction Continue 2>&1 \| Write-Output/g) ?? []).toHaveLength(2);
-    expect(runGates).toContain('Write-Output "::group::$($finished.Name)"');
-    expect(runGates).toContain('Write-Output "::group::$($job.Name)"');
-
-    expect(runGates).toContain('gate:$($check.Name)=pass');
-    expect(runGates).toContain('gate:$($check.Name)=fail');
-    expect(runGates).toContain('if ($failed) { exit 1 }');
-    expect(runGates).not.toContain('actionlint');
-    expect(runGates).not.toContain('commitlint');
+    expect(windows).toContain("if: steps.windows-node-modules.outputs.cache-hit != 'true'");
+    expect(windows).toContain('run: npm ci --prefer-offline --no-audit --no-fund');
+    expect(windows.match(/npm ci --prefer-offline --no-audit --no-fund/g) ?? []).toHaveLength(1);
+    expect(windows.match(/^\s*- run: npm ci\s*$/gm) ?? []).toHaveLength(0);
   });
 
-  it(
-    'drains Windows gate diagnostics before failing the process when npm test exits nonzero',
-    () => {
-      const script = extractWindowsRunGatesBody(workflow);
-      expect(script).toContain('& npm @npmArgs');
-      expect(script).not.toContain('Invoke-Expression');
+  it('runs direct unfiltered npm test unconditionally and skips only install on cache hit', () => {
+    expect(windows.match(/^\s*- run: npm test\s*$/gm) ?? []).toHaveLength(1);
+    expect(windows).not.toMatch(/npm test --/);
+    expect(windows).not.toMatch(/npm test -/);
 
-      const fixture = mkdtempSync(join(tmpdir(), 'aws-ci-windows-gates-'));
-      try {
-        writeFileSync(
-          join(fixture, 'package.json'),
-          `${JSON.stringify(
-            {
-              name: 'aws-ci-windows-gates-fixture',
-              private: true,
-              scripts: {
-                lint: 'node -e "console.error(\'benign stderr from passing lint\')"',
-                test: 'node -e "process.exit(1)"',
-                typecheck: 'node -e "process.exit(0)"',
-                'verify:dist:assert': 'node -e "process.exit(0)"',
-              },
-            },
-            null,
-            2,
-          )}\n`,
-        );
-        writeFileSync(join(fixture, 'run-gates.ps1'), `${script}\n`);
+    const stepsAfterCache = windows.slice(windows.indexOf('id: windows-node-modules'));
+    expect(stepsAfterCache).toContain('- run: npm test');
+    expect(stepsAfterCache).not.toMatch(/- run: npm test\n\s+if:/);
 
-        const result = spawnSync('pwsh', ['-NoProfile', '-File', 'run-gates.ps1'], {
-          cwd: fixture,
-          encoding: 'utf8',
-          timeout: 30_000,
-        });
-        const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+    const testIdx = windows.search(/^\s*- run: npm test\s*$/m);
+    const preceding = windows.slice(Math.max(0, testIdx - 80), testIdx);
+    expect(preceding).not.toMatch(/if:.*\n\s*- run: npm test/);
+  });
 
-        expect(result.error, output).toBeUndefined();
-        expect(result.signal, output).toBeNull();
-        expect(result.status, output).not.toBe(0);
-        expect(output).toContain('benign stderr from passing lint');
-        expect(output).toContain('::group::lint');
-        expect(output).toContain('::group::test');
-        expect(output).toContain('::group::typecheck');
-        expect(output).toContain('::group::dist');
-        expect(output).toContain('gate:lint=pass');
-        expect(output).toContain('gate:test=fail');
-        expect(output).toContain('gate:typecheck=pass');
-        expect(output).toContain('gate:dist=pass');
-        expect(output).toMatch(/gate:lint=(?:pass|fail)/);
-        expect(output).toMatch(/gate:test=(?:pass|fail)/);
-        expect(output).toMatch(/gate:typecheck=(?:pass|fail)/);
-        expect(output).toMatch(/gate:dist=(?:pass|fail)/);
-      } finally {
-        rmSync(fixture, { recursive: true, force: true });
-      }
-    },
-    60_000,
-  );
+  it('omits Windows build/bundle/lint/typecheck/dist/queue work', () => {
+    expect(windows).not.toContain('npm run bundle');
+    expect(windows).not.toContain('npm run build');
+    expect(windows).not.toContain('npm run lint');
+    expect(windows).not.toContain('npm run typecheck');
+    expect(windows).not.toContain('verify:dist');
+    expect(windows).not.toContain('MAX_PARALLEL_GATES');
+    expect(windows).not.toContain('$maxParallelGates');
+    expect(windows).not.toContain('Start-Job');
+    expect(windows).not.toContain('Wait-Job');
+    expect(windows).not.toContain('Receive-Job');
+    expect(windows).not.toContain('Run gates');
+    expect(windows).not.toContain('shell: pwsh');
+    expect(windows).not.toMatch(/@\{ Name = '/);
+
+    // Linux still owns the full gate set; Windows is test-only.
+    expect(linux).toContain('npm run bundle');
+    expect(linux).toContain('run lint       npm run lint');
+    expect(linux).toContain('run typecheck  npm run typecheck');
+    expect(linux).toContain('run dist       npm run verify:dist:assert');
+
+    const upload = namedStep(linux, 'Upload expected dist on mismatch');
+    expect(upload).toContain('if: failure()');
+    expect(upload).toContain('uses: actions/upload-artifact@v7');
+    expect(upload).toContain('name: expected-dist');
+    expect(upload).toContain('path: dist/');
+  });
 });

--- a/tests/cli-packaging.test.ts
+++ b/tests/cli-packaging.test.ts
@@ -1,5 +1,18 @@
 import { execFile, spawnSync } from 'node:child_process';
-import { access, constants, lstat, mkdir, mkdtemp, readFile, readdir, rm, stat, symlink } from 'node:fs/promises';
+import {
+  access,
+  constants,
+  cp,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  symlink,
+  writeFile
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -13,6 +26,18 @@ const npmCliArgs = process.platform === 'win32' ? [process.env.npm_execpath || '
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const tempDirs: string[] = [];
 
+const EXPECTED_PACKAGE_NAME = '@postman-cse/onboarding-aws-spec-discovery';
+const EXPECTED_BIN_NAME = 'postman-aws-spec-discovery';
+const EXPECTED_PACK_CENSUS = [
+  'action.yml',
+  'dist/cli.cjs',
+  'dist/index.cjs',
+  'README.md',
+  'SECURITY.md',
+  'SUPPORT.md',
+  'RELEASE_POLICY.md'
+] as const;
+
 afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
@@ -21,6 +46,388 @@ async function makeTempDir(prefix: string): Promise<string> {
   const dir = await mkdtemp(path.join(tmpdir(), prefix));
   tempDirs.push(dir);
   return dir;
+}
+
+type PackStrategy = 'posix-install' | 'win32-native-shim';
+
+function resolvePackStrategy(platform: NodeJS.Platform = process.platform): PackStrategy {
+  return platform === 'win32' ? 'win32-native-shim' : 'posix-install';
+}
+
+type PlannedCommand = Readonly<{ file: string; args: readonly string[] }>;
+
+type PackedPackageMeta = {
+  name: string;
+  version: string;
+  binName: string;
+  binTarget: string;
+};
+
+type Win32NativeShimPlan = {
+  strategy: 'win32-native-shim';
+  plannedCommands: PlannedCommand[];
+  extractRoot: string;
+  proxyRoot: string;
+  tarballPath: string;
+  packageRoot: string;
+  installedPackageDir: string;
+  cmdShimPath: string;
+  cliPath: string;
+  meta: PackedPackageMeta;
+};
+
+const CMD_UNSAFE_CHARS = /[\r\n"%!^&|<>]/;
+const SAFE_PACKAGE_NAME = /^(?:@[A-Za-z0-9._~-]+\/)?[A-Za-z0-9._~-]+$/;
+const SAFE_BIN_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const FIXED_NATIVE_CMD_ARGS = new Set(['--help', '--version']);
+
+function assertPathInsideRoot(candidate: string, root: string, label: string): string {
+  const resolvedCandidate = path.resolve(candidate);
+  const resolvedRoot = path.resolve(root);
+  const relative = path.relative(resolvedRoot, resolvedCandidate);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`${label} escapes root: ${resolvedCandidate} not under ${resolvedRoot}`);
+  }
+  return resolvedCandidate;
+}
+
+function assertNoCmdMetacharacters(value: string, label: string): string {
+  if (value.length === 0) {
+    throw new Error(`${label} must be non-empty`);
+  }
+  if (CMD_UNSAFE_CHARS.test(value)) {
+    throw new Error(`${label} contains unsafe cmd metacharacters`);
+  }
+  return value;
+}
+
+function assertSafePackageName(name: string): string {
+  assertNoCmdMetacharacters(name, 'package name');
+  if (!SAFE_PACKAGE_NAME.test(name)) {
+    throw new Error(`unsafe package-name syntax: ${name}`);
+  }
+  return name;
+}
+
+function assertSafeBinName(binName: string): string {
+  assertNoCmdMetacharacters(binName, 'bin name');
+  if (!SAFE_BIN_NAME.test(binName)) {
+    throw new Error(`unsafe bin-name syntax: ${binName}`);
+  }
+  return binName;
+}
+
+function assertSafeBinTarget(binTarget: string): string {
+  assertNoCmdMetacharacters(binTarget, 'bin target');
+  const normalized = binTarget.replace(/\\/g, '/');
+  if (
+    path.isAbsolute(binTarget) ||
+    path.win32.isAbsolute(binTarget) ||
+    path.posix.isAbsolute(normalized) ||
+    normalized.split('/').includes('..') ||
+    normalized.startsWith('~')
+  ) {
+    throw new Error(`bin target must be a relative path without ..: ${binTarget}`);
+  }
+  return binTarget;
+}
+
+function quoteCmdArg(value: string): string {
+  // Reject rather than silently strip quotes or other cmd metacharacters.
+  assertNoCmdMetacharacters(value, 'cmd arg');
+  return `"${value}"`;
+}
+
+function resolveComSpec(): string {
+  return process.env.ComSpec ?? process.env.COMSPEC ?? 'cmd.exe';
+}
+
+function planNativeCmdInvocation(cmdShimPath: string, args: readonly string[]): PlannedCommand {
+  assertNoCmdMetacharacters(cmdShimPath, 'cmdShimPath');
+  for (const arg of args) {
+    if (!FIXED_NATIVE_CMD_ARGS.has(arg)) {
+      throw new Error(`native cmd arg not allowed: ${arg}`);
+    }
+    assertNoCmdMetacharacters(arg, 'cmd arg');
+  }
+  const commandPayload = [quoteCmdArg(cmdShimPath), ...args.map((arg) => quoteCmdArg(arg))].join(' ');
+  // Node's Windows shell contract: ComSpec /d /s /c "<command>", with the payload quoted.
+  return {
+    file: resolveComSpec(),
+    args: ['/d', '/s', '/c', `"${commandPayload}"`]
+  };
+}
+
+function packageDirSegments(packageName: string): string[] {
+  assertSafePackageName(packageName);
+  return packageName.startsWith('@') ? packageName.split('/') : [packageName];
+}
+
+function resolveBinEntry(
+  bin: string | Record<string, string> | undefined,
+  packageName: string
+): { binName: string; binTarget: string } {
+  assertSafePackageName(packageName);
+  if (typeof bin === 'string') {
+    const binName = packageName.includes('/') ? packageName.split('/')[1]! : packageName;
+    return {
+      binName: assertSafeBinName(binName),
+      binTarget: assertSafeBinTarget(bin)
+    };
+  }
+  if (!bin || typeof bin !== 'object') {
+    throw new Error('packed package.json is missing a bin entry');
+  }
+  const entries = Object.entries(bin);
+  expect(entries.length).toBeGreaterThan(0);
+  const [binName, binTarget] = entries[0]!;
+  return {
+    binName: assertSafeBinName(binName),
+    binTarget: assertSafeBinTarget(binTarget)
+  };
+}
+
+async function npmPackJson(packDir: string): Promise<{ filename: string; name: string; files: Array<{ path: string }> }> {
+  const packResult = await execFileAsync(
+    npmCommand,
+    [...npmCliArgs, 'pack', '--json', '--pack-destination', packDir],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env: {
+        NPM_CONFIG_CACHE: path.join(packDir, '.npm-cache'),
+        PATH: process.env.PATH ?? ''
+      },
+      maxBuffer: 20 * 1024 * 1024
+    }
+  );
+  const [packed] = JSON.parse(packResult.stdout) as Array<{
+    filename: string;
+    name: string;
+    files: Array<{ path: string }>;
+  }>;
+  expect(packed.name).toBe(EXPECTED_PACKAGE_NAME);
+  return packed;
+}
+
+function assertPackedCensus(files: Array<{ path: string }>): void {
+  const filePaths = new Set(files.map((file) => file.path));
+  for (const required of EXPECTED_PACK_CENSUS) {
+    expect(filePaths.has(required), `npm pack must include ${required}`).toBe(true);
+  }
+}
+
+async function extractPackedTarball(tarballPath: string, extractRoot: string): Promise<string> {
+  await mkdir(extractRoot, { recursive: true });
+  await execFileAsync('tar', ['-xzf', tarballPath, '-C', extractRoot], {
+    encoding: 'utf8',
+    maxBuffer: 20 * 1024 * 1024
+  });
+  return path.join(extractRoot, 'package');
+}
+
+async function readPackedMeta(packageRoot: string): Promise<PackedPackageMeta> {
+  const packageJson = JSON.parse(await readFile(path.join(packageRoot, 'package.json'), 'utf8')) as {
+    name: string;
+    version: string;
+    bin?: string | Record<string, string>;
+  };
+  const { binName, binTarget } = resolveBinEntry(packageJson.bin, packageJson.name);
+  return {
+    name: packageJson.name,
+    version: packageJson.version,
+    binName,
+    binTarget
+  };
+}
+
+function planWin32NativeShim(args: {
+  extractRoot: string;
+  proxyRoot: string;
+  tarballPath: string;
+  meta: PackedPackageMeta;
+}): Win32NativeShimPlan {
+  assertSafePackageName(args.meta.name);
+  assertSafeBinName(args.meta.binName);
+  assertSafeBinTarget(args.meta.binTarget);
+  assertNoCmdMetacharacters(args.extractRoot, 'extractRoot');
+  assertNoCmdMetacharacters(args.proxyRoot, 'proxyRoot');
+  assertNoCmdMetacharacters(args.tarballPath, 'tarballPath');
+
+  const packageRoot = path.join(args.extractRoot, 'package');
+  const installedPackageDir = path.join(args.proxyRoot, 'node_modules', ...packageDirSegments(args.meta.name));
+  const binDir = path.join(args.proxyRoot, 'node_modules', '.bin');
+  const cmdShimPath = path.join(binDir, `${args.meta.binName}.cmd`);
+  const cliPath = path.join(installedPackageDir, args.meta.binTarget);
+
+  assertPathInsideRoot(packageRoot, args.extractRoot, 'packageRoot');
+  assertPathInsideRoot(installedPackageDir, args.proxyRoot, 'installedPackageDir');
+  assertPathInsideRoot(cmdShimPath, args.proxyRoot, 'cmdShimPath');
+  assertPathInsideRoot(cliPath, args.proxyRoot, 'cliPath');
+  assertNoCmdMetacharacters(cmdShimPath, 'cmdShimPath');
+  assertNoCmdMetacharacters(cliPath, 'cliPath');
+
+  const plannedCommands: PlannedCommand[] = [
+    { file: npmCommand, args: [...npmCliArgs, 'pack', '--json', '--pack-destination', path.dirname(args.tarballPath)] },
+    { file: 'tar', args: ['-xzf', args.tarballPath, '-C', args.extractRoot] },
+    planNativeCmdInvocation(cmdShimPath, ['--help']),
+    planNativeCmdInvocation(cmdShimPath, ['--version'])
+  ];
+
+  for (const command of plannedCommands) {
+    expect(command.file).not.toMatch(/install/i);
+    expect(command.args.join(' ')).not.toMatch(/(?:^|\s)install(?:\s|$)/i);
+  }
+
+  return {
+    strategy: 'win32-native-shim',
+    plannedCommands,
+    extractRoot: args.extractRoot,
+    proxyRoot: args.proxyRoot,
+    tarballPath: args.tarballPath,
+    packageRoot,
+    installedPackageDir,
+    cmdShimPath,
+    cliPath,
+    meta: args.meta
+  };
+}
+
+async function materializeWin32NativeShim(plan: Win32NativeShimPlan): Promise<void> {
+  await mkdir(path.dirname(plan.installedPackageDir), { recursive: true });
+  await cp(plan.packageRoot, plan.installedPackageDir, { recursive: true });
+  await mkdir(path.dirname(plan.cmdShimPath), { recursive: true });
+
+  const cliPath = assertPathInsideRoot(plan.cliPath, plan.proxyRoot, 'cliPath');
+  const body = ['@ECHO off', `${quoteCmdArg(process.execPath)} ${quoteCmdArg(cliPath)} %*`, ''].join('\r\n');
+  await writeFile(plan.cmdShimPath, body, 'utf8');
+}
+
+async function executeNativeCmd(cmdShimPath: string, args: string[]): Promise<{ stdout: string; stderr: string; status: number | null }> {
+  const planned = planNativeCmdInvocation(cmdShimPath, args);
+  const result = spawnSync(planned.file, [...planned.args], {
+    encoding: 'utf8',
+    windowsVerbatimArguments: true,
+    env: {
+      PATH: process.env.PATH ?? '',
+      INPUT_AWS_REGION: '',
+      AWS_REGION: '',
+      AWS_DEFAULT_REGION: '',
+      INPUT_POSTMAN_API_KEY: '',
+      POSTMAN_API_KEY: ''
+    },
+    timeout: 20_000,
+    maxBuffer: 1024 * 1024
+  });
+  return {
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    status: result.status
+  };
+}
+
+async function runPosixInstallPackaging(): Promise<void> {
+  const packDir = await makeTempDir('postman-aws-spec-pack-');
+  const prefixDir = await makeTempDir('postman-aws-spec-prefix-');
+
+  const packed = await npmPackJson(packDir);
+  assertPackedCensus(packed.files);
+
+  const tarballPath = path.join(packDir, packed.filename);
+  await mkdir(prefixDir, { recursive: true });
+  await execFileAsync(npmCommand, [...npmCliArgs, 'install', '--prefix', prefixDir, tarballPath], {
+    encoding: 'utf8',
+    env: {
+      NPM_CONFIG_CACHE: path.join(packDir, '.npm-cache'),
+      PATH: process.env.PATH ?? ''
+    },
+    maxBuffer: 20 * 1024 * 1024
+  });
+
+  const binPath = path.join(prefixDir, 'node_modules', '.bin', EXPECTED_BIN_NAME);
+  const binStat = await lstat(binPath);
+  expect(binStat.isSymbolicLink() || binStat.isFile()).toBe(true);
+
+  const installedCli = path.join(
+    prefixDir,
+    'node_modules',
+    '@postman-cse',
+    'onboarding-aws-spec-discovery',
+    'dist',
+    'cli.cjs'
+  );
+  const help = await execFileAsync(process.execPath, [installedCli, '--help'], {
+    encoding: 'utf8',
+    env: {
+      PATH: process.env.PATH ?? '',
+      INPUT_AWS_REGION: '',
+      AWS_REGION: '',
+      AWS_DEFAULT_REGION: '',
+      INPUT_POSTMAN_API_KEY: '',
+      POSTMAN_API_KEY: ''
+    },
+    maxBuffer: 1024 * 1024
+  });
+
+  expect(help.stdout).toMatch(/Usage:\s+postman-aws-spec-discovery/i);
+  expect(help.stderr).not.toMatch(/permission denied|exec format|syntax error|unexpected token|"use strict"/i);
+  expect(help.stdout).not.toMatch(/"use strict"/);
+
+  const version = await execFileAsync(process.execPath, [installedCli, '--version'], {
+    encoding: 'utf8',
+    env: { PATH: process.env.PATH ?? '' },
+    maxBuffer: 1024 * 1024
+  });
+  const packageJson = JSON.parse(await readFile(path.join(repoRoot, 'package.json'), 'utf8')) as {
+    version: string;
+  };
+  expect(version.stdout.trim()).toBe(packageJson.version);
+
+  const symlinkDir = await makeTempDir('postman-aws-spec-symlink-');
+  const symlinkPath = path.join(symlinkDir, EXPECTED_BIN_NAME);
+  await symlink(installedCli, symlinkPath);
+  const symlinkHelp = spawnSync(symlinkPath, ['--help'], {
+    encoding: 'utf8',
+    env: { PATH: process.env.PATH ?? '' }
+  });
+  expect(symlinkHelp.status).toBe(0);
+  expect(symlinkHelp.stdout).toMatch(/Usage:\s+postman-aws-spec-discovery/i);
+}
+
+async function runWin32NativeShimPackaging(options: { executeCmd: boolean }): Promise<Win32NativeShimPlan> {
+  const packDir = await makeTempDir('postman-aws-spec-pack-');
+  const extractRoot = await makeTempDir('postman-aws-spec-extract-');
+  const proxyRoot = await makeTempDir('postman-aws-spec-proxy-');
+
+  const packed = await npmPackJson(packDir);
+  assertPackedCensus(packed.files);
+  const tarballPath = path.join(packDir, packed.filename);
+
+  const packageRoot = await extractPackedTarball(tarballPath, extractRoot);
+  const meta = await readPackedMeta(packageRoot);
+  expect(meta.name).toBe(EXPECTED_PACKAGE_NAME);
+  expect(meta.binName).toBe(EXPECTED_BIN_NAME);
+  expect(meta.binTarget.replace(/\\/g, '/')).toBe('dist/cli.cjs');
+
+  const plan = planWin32NativeShim({ extractRoot, proxyRoot, tarballPath, meta });
+  expect(plan.strategy).toBe('win32-native-shim');
+  expect(plan.plannedCommands.some((command) => command.args.includes('install'))).toBe(false);
+
+  await materializeWin32NativeShim(plan);
+  await access(plan.cliPath, constants.F_OK);
+
+  if (options.executeCmd) {
+    const help = await executeNativeCmd(plan.cmdShimPath, ['--help']);
+    expect(help.status).toBe(0);
+    expect(help.stdout).toMatch(/Usage:\s+postman-aws-spec-discovery/i);
+    expect(help.stderr).not.toMatch(/permission denied|exec format|syntax error|unexpected token|"use strict"/i);
+
+    const version = await executeNativeCmd(plan.cmdShimPath, ['--version']);
+    expect(version.status).toBe(0);
+    expect(version.stdout.trim()).toBe(meta.version);
+  }
+
+  return plan;
 }
 
 describe('CLI packaging contract', () => {
@@ -56,7 +463,7 @@ describe('CLI packaging contract', () => {
       .sort();
     expect(entries).toEqual(['cli.cjs', 'index.cjs']);
 
-    const onDisk = await (await import('node:fs/promises')).readdir(distDir);
+    const onDisk = await readdir(distDir);
     expect(onDisk.filter((name) => !name.startsWith('.')).sort()).toEqual(['cli.cjs', 'index.cjs']);
   });
 
@@ -93,7 +500,7 @@ describe('CLI packaging contract', () => {
 
   it('bundles once before CI fan-out and runs only the read-only dist assertion in-gate', async () => {
     const workflow = await readFile(path.join(repoRoot, '.github', 'workflows', 'ci.yml'), 'utf8');
-    expect(workflow.match(/npm run bundle/g)).toHaveLength(2);
+    expect(workflow.match(/npm run bundle/g)).toHaveLength(1);
     expect(workflow).toContain('runs-on: windows-latest');
     expect(workflow).toContain('run dist       npm run verify:dist:assert');
     expect(workflow).toContain('MAX_PARALLEL_GATES=2');
@@ -102,100 +509,103 @@ describe('CLI packaging contract', () => {
     expect(workflow.indexOf('- run: npm run bundle')).toBeLessThan(workflow.indexOf('- name: Run gates'));
   });
 
-  it('packs, installs, and runs .bin --help via symlink invocation', async () => {
-    const packDir = await makeTempDir('postman-aws-spec-pack-');
-    const prefixDir = await makeTempDir('postman-aws-spec-prefix-');
+  it('selects posix install off Windows and win32 native shim on Windows', () => {
+    expect(resolvePackStrategy('linux')).toBe('posix-install');
+    expect(resolvePackStrategy('darwin')).toBe('posix-install');
+    expect(resolvePackStrategy('win32')).toBe('win32-native-shim');
+    expect(resolvePackStrategy()).toBe(process.platform === 'win32' ? 'win32-native-shim' : 'posix-install');
+  });
 
-    const packResult = await execFileAsync(
-      npmCommand,
-      [...npmCliArgs, 'pack', '--json', '--pack-destination', packDir],
-      {
-        cwd: repoRoot,
-        encoding: 'utf8',
-        env: {
-          NPM_CONFIG_CACHE: path.join(packDir, '.npm-cache'),
-          PATH: process.env.PATH ?? ''
-        },
-        maxBuffer: 20 * 1024 * 1024
+  it(
+    'packs and exercises the platform packaging seam without a cold Windows production install',
+    async () => {
+      const strategy = resolvePackStrategy();
+      if (strategy === 'posix-install') {
+        await runPosixInstallPackaging();
+      } else {
+        await runWin32NativeShimPackaging({ executeCmd: true });
       }
-    );
-    const [packed] = JSON.parse(packResult.stdout) as Array<{
-      filename: string;
-      name: string;
-    }>;
-    expect(packed.name).toBe('@postman-cse/onboarding-aws-spec-discovery');
+    },
+    90_000
+  );
 
-    const tarballPath = path.join(packDir, packed.filename);
-    await mkdir(prefixDir, { recursive: true });
-    await execFileAsync(npmCommand, [...npmCliArgs, 'install', '--prefix', prefixDir, tarballPath], {
-      encoding: 'utf8',
-      env: {
-        NPM_CONFIG_CACHE: path.join(packDir, '.npm-cache'),
-        PATH: process.env.PATH ?? ''
-      },
-      maxBuffer: 20 * 1024 * 1024
-    });
+  it(
+    'Linux-local win32 strategy plans a native .cmd seam with no npm install',
+    async () => {
+      // Explicitly target win32 even on Linux/macOS so the command plan is proven here.
+      expect(resolvePackStrategy('win32')).toBe('win32-native-shim');
+      const plan = await runWin32NativeShimPackaging({ executeCmd: process.platform === 'win32' });
+      expect(plan.strategy).toBe('win32-native-shim');
+      expect(plan.plannedCommands.map((command) => [command.file, ...command.args].join(' ')).join('\n')).not.toMatch(
+        /(?:^|\s)(?:npm(?:\.cmd)?\s+)?install(?:\s|$)/i
+      );
+      for (const command of plan.plannedCommands) {
+        expect(command.args).not.toContain('install');
+        expect(command.file.toLowerCase()).not.toContain('install');
+      }
+      expect(plan.cmdShimPath.endsWith(`${path.sep}${EXPECTED_BIN_NAME}.cmd`)).toBe(true);
+      await access(plan.cmdShimPath, constants.F_OK);
+      const shimBody = await readFile(plan.cmdShimPath, 'utf8');
+      expect(shimBody).toContain(quoteCmdArg(plan.cliPath));
+      expect(shimBody).toMatch(/\.cmd|\.cjs|node/i);
+    },
+    60_000
+  );
 
-    const binPath = path.join(
-      prefixDir,
-      'node_modules',
-      '.bin',
-      process.platform === 'win32' ? 'postman-aws-spec-discovery.cmd' : 'postman-aws-spec-discovery'
-    );
+  it('rejects malicious bin metadata and path tokens before spawn', () => {
+    expect(() => assertSafeBinName('evil&whoami')).toThrow(/unsafe cmd metacharacters/);
+    expect(() => assertSafeBinName('evil|calc')).toThrow(/unsafe cmd metacharacters/);
+    expect(() => assertSafeBinName('x%PATH%')).toThrow(/unsafe cmd metacharacters/);
+    expect(() => assertSafeBinName('x!var!')).toThrow(/unsafe cmd metacharacters/);
+    expect(() => assertSafeBinName('x^y')).toThrow(/unsafe cmd metacharacters/);
+    expect(() => assertSafeBinName('x<y')).toThrow(/unsafe cmd metacharacters/);
+    expect(() => assertSafeBinName('x>y')).toThrow(/unsafe cmd metacharacters/);
+    expect(() => assertSafeBinName('quoted"name')).toThrow(/unsafe cmd metacharacters/);
+    expect(() => assertSafeBinName('line\rname')).toThrow(/unsafe cmd metacharacters/);
+    expect(() => assertSafeBinName('line\nname')).toThrow(/unsafe cmd metacharacters/);
+    expect(() => assertSafeBinTarget('dist/cli.cjs&calc')).toThrow(/unsafe cmd metacharacters/);
+    expect(() => assertSafeBinTarget('../escape.cjs')).toThrow(/relative path/);
+    expect(() => assertSafeBinTarget('/abs/cli.cjs')).toThrow(/relative path/);
+    expect(() => assertSafePackageName('@scope/evil&name')).toThrow(/unsafe cmd metacharacters/);
+    expect(() => quoteCmdArg('has"quote')).toThrow(/unsafe cmd metacharacters/);
+    expect(() => planNativeCmdInvocation('C:\\safe\\bin.cmd', ['--help&whoami'])).toThrow(/not allowed/);
+    expect(() => planNativeCmdInvocation('C:\\safe\\bin&evil.cmd', ['--help'])).toThrow(/unsafe cmd metacharacters/);
 
-    if (process.platform !== 'win32') {
-      const binStat = await lstat(binPath);
-      expect(binStat.isSymbolicLink() || binStat.isFile()).toBe(true);
-    }
+    const extractRoot = path.join(tmpdir(), 'safe-extract');
+    const proxyRoot = path.join(tmpdir(), 'safe-proxy');
+    expect(() =>
+      planWin32NativeShim({
+        extractRoot,
+        proxyRoot,
+        tarballPath: path.join(extractRoot, 'pkg.tgz'),
+        meta: {
+          name: EXPECTED_PACKAGE_NAME,
+          version: '0.0.0',
+          binName: 'postman&aws',
+          binTarget: 'dist/cli.cjs'
+        }
+      })
+    ).toThrow(/unsafe cmd metacharacters/);
+  });
 
-    const installedCli = path.join(
-      prefixDir,
-      'node_modules',
-      '@postman-cse',
-      'onboarding-aws-spec-discovery',
-      'dist',
-      'cli.cjs'
-    );
-    const help = await execFileAsync(process.execPath, [installedCli, '--help'], {
-      encoding: 'utf8',
-      env: {
-        PATH: process.env.PATH ?? '',
-        INPUT_AWS_REGION: '',
-        AWS_REGION: '',
-        AWS_DEFAULT_REGION: '',
-        INPUT_POSTMAN_API_KEY: '',
-        POSTMAN_API_KEY: ''
-      },
-      maxBuffer: 1024 * 1024
-    });
+  it('plans a quoted cmd.exe invocation for safe metadata without shell true', () => {
+    const safeShim = path.join(tmpdir(), 'proxy', 'node_modules', '.bin', `${EXPECTED_BIN_NAME}.cmd`);
+    const planned = planNativeCmdInvocation(safeShim, ['--help']);
+    const commandPayload = [quoteCmdArg(safeShim), quoteCmdArg('--help')].join(' ');
+    expect(planned.file).toBe(process.env.ComSpec ?? process.env.COMSPEC ?? 'cmd.exe');
+    expect(planned.args).toEqual(['/d', '/s', '/c', `"${commandPayload}"`]);
+    expect(planned.args[3]).toContain(quoteCmdArg(safeShim));
+    expect(planned.args[3]).toContain(quoteCmdArg('--help'));
+    expect(planned.args.join(' ')).not.toMatch(/\beval\b/);
+  });
 
-    expect(help.stdout).toMatch(/Usage:\s+postman-aws-spec-discovery/i);
-    expect(help.stderr).not.toMatch(/permission denied|exec format|syntax error|unexpected token|"use strict"/i);
-    expect(help.stdout).not.toMatch(/"use strict"/);
-
-    const version = await execFileAsync(process.execPath, [installedCli, '--version'], {
-      encoding: 'utf8',
-      env: { PATH: process.env.PATH ?? '' },
-      maxBuffer: 1024 * 1024
-    });
-    const packageJson = JSON.parse(await readFile(path.join(repoRoot, 'package.json'), 'utf8')) as {
-      version: string;
-    };
-    expect(version.stdout.trim()).toBe(packageJson.version);
-
-    if (process.platform !== 'win32') {
-      const symlinkDir = await makeTempDir('postman-aws-spec-symlink-');
-      const symlinkPath = path.join(symlinkDir, 'postman-aws-spec-discovery');
-      await symlink(installedCli, symlinkPath);
-      const symlinkHelp = spawnSync(symlinkPath, ['--help'], {
-        encoding: 'utf8',
-        env: { PATH: process.env.PATH ?? '' }
-      });
-      expect(symlinkHelp.status).toBe(0);
-      expect(symlinkHelp.stdout).toMatch(/Usage:\s+postman-aws-spec-discovery/i);
-    }
-    // npm pack/install exercises the published-package path and can require a cold local npm cache.
-  }, 240000);
+  it('keeps native shim execution source free of shell true', async () => {
+    const source = await readFile(fileURLToPath(import.meta.url), 'utf8');
+    // Build the forbidden token at runtime so this assertion text cannot self-match.
+    const shellTrue = ['shell', 'true'].join(': ');
+    expect(source.includes(shellTrue)).toBe(false);
+    expect(source).not.toMatch(/shell\s*:\s*true/);
+  });
 
   it('runs the direct dist/cli.cjs artifact with a shebang path', async () => {
     if (process.platform === 'win32') return;


### PR DESCRIPTION
## Summary
- Retain Linux full CI gates unchanged while accelerating the Windows parity path.
- Run Windows direct full `npm test` with exact cache cold fallback.
- Keep AWS POSIX real install and Windows packed metadata-derived native cmd shim behavior.
- Validators run on this branch: `npm test`, `npm run typecheck`, `npm run lint`, `npm run bundle`, `npm run verify:dist:assert`, and `git diff --check origin/main...HEAD`.

## Test plan
- [ ] Confirm CI Linux full gates remain intact
- [ ] Confirm Windows parity job uses direct full npm test with cache cold fallback
- [ ] Confirm AWS packaging assertions for POSIX install and Windows cmd shim still pass