### PR TITLE
ci: run Windows suite via node --run test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,4 +111,4 @@ jobs:
           key: Windows/node-24/exact-${{ hashFiles('package-lock.json') }}
       - if: steps.windows-node-modules.outputs.cache-hit != 'true'
         run: npm ci --prefer-offline --no-audit --no-fund
-      - run: npm test
+      - run: node --run test

--- a/tests/ci-workflow.test.ts
+++ b/tests/ci-workflow.test.ts
@@ -126,18 +126,18 @@ describe('CI workflow contract', () => {
     expect(windows.match(/^\s*- run: npm ci\s*$/gm) ?? []).toHaveLength(0);
   });
 
-  it('runs direct unfiltered npm test unconditionally and skips only install on cache hit', () => {
-    expect(windows.match(/^\s*- run: npm test\s*$/gm) ?? []).toHaveLength(1);
+  it('runs direct unfiltered node --run test unconditionally and skips only install on cache hit', () => {
+    expect(windows.match(/^\s*- run: node --run test\s*$/gm) ?? []).toHaveLength(1);
     expect(windows).not.toMatch(/npm test --/);
     expect(windows).not.toMatch(/npm test -/);
 
     const stepsAfterCache = windows.slice(windows.indexOf('id: windows-node-modules'));
-    expect(stepsAfterCache).toContain('- run: npm test');
-    expect(stepsAfterCache).not.toMatch(/- run: npm test\n\s+if:/);
+    expect(stepsAfterCache).toContain('- run: node --run test');
+    expect(stepsAfterCache).not.toMatch(/- run: node --run test\n\s+if:/);
 
-    const testIdx = windows.search(/^\s*- run: npm test\s*$/m);
+    const testIdx = windows.search(/^\s*- run: node --run test\s*$/m);
     const preceding = windows.slice(Math.max(0, testIdx - 80), testIdx);
-    expect(preceding).not.toMatch(/if:.*\n\s*- run: npm test/);
+    expect(preceding).not.toMatch(/if:.*\n\s*- run: node --run test/);
   });
 
   it('omits Windows build/bundle/lint/typecheck/dist/queue work', () => {

--- a/tests/cli-packaging.test.ts
+++ b/tests/cli-packaging.test.ts
@@ -21,8 +21,15 @@ import { promisify } from 'node:util';
 import { afterEach, describe, expect, it } from 'vitest';
 
 const execFileAsync = promisify(execFile);
+const npmCliFallback = path.join(path.dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npm-cli.js');
+
+function resolveNpmCliArgs(platform: NodeJS.Platform, npmExecPath: string | undefined): readonly string[] {
+  if (platform !== 'win32') return [];
+  return [npmExecPath || npmCliFallback];
+}
+
 const npmCommand = process.platform === 'win32' ? process.execPath : 'npm';
-const npmCliArgs = process.platform === 'win32' ? [process.env.npm_execpath || ''] : [];
+const npmCliArgs = resolveNpmCliArgs(process.platform, process.env.npm_execpath);
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const tempDirs: string[] = [];
 
@@ -431,6 +438,15 @@ async function runWin32NativeShimPackaging(options: { executeCmd: boolean }): Pr
 }
 
 describe('CLI packaging contract', () => {
+  it('keeps Windows npm CLI args non-empty under node --run', () => {
+    const underNodeRun = resolveNpmCliArgs('win32', undefined);
+    expect(underNodeRun).toEqual([npmCliFallback]);
+    expect(underNodeRun.every((arg) => arg.length > 0)).toBe(true);
+    expect(resolveNpmCliArgs('win32', '/custom/npm-cli.js')).toEqual(['/custom/npm-cli.js']);
+    expect(resolveNpmCliArgs('linux', undefined)).toEqual([]);
+    expect(npmCliArgs.every((arg) => arg.length > 0)).toBe(true);
+  });
+
   it('commits a Node shebang and git-index executable mode on dist/cli.cjs', async () => {
     const cliPath = path.join(repoRoot, 'dist', 'cli.cjs');
     const contents = await readFile(cliPath, 'utf8');


### PR DESCRIPTION
CI-only: Windows gate uses `node --run test` instead of `npm test` to avoid npm.cmd boot overhead. Committed-dist unchanged; no rebuild; no release topology change.