### PR TITLE
fix(release): reconcile incomplete cuts before new tags

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -12,6 +12,9 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
 
 permissions:
   contents: read
@@ -23,7 +26,7 @@ concurrency:
 
 jobs:
   cut:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -35,15 +38,79 @@ jobs:
           # cut so it can skip burnt versions instead of reusing them.
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Reconcile prior release
+        id: reconcile
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ROLLING_ALIASES: major
+        run: |
+          set -euo pipefail
+          LATEST=""
+          while IFS= read -r CANDIDATE; do
+            if [[ "$CANDIDATE" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              EXPECTED="${CANDIDATE#v}"
+            elif [[ "$CANDIDATE" =~ ^v[0-9]+\.[0-9]+$ ]]; then
+              EXPECTED="${CANDIDATE#v}.0"
+            else
+              continue
+            fi
+            if ! PACKAGE_VERSION="$(git show "${CANDIDATE}^{commit}:package.json" 2>/dev/null | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version" 2>/dev/null)"; then
+              continue
+            fi
+            [ "$PACKAGE_VERSION" = "$EXPECTED" ] || continue
+            LATEST="$CANDIDATE"
+          done < <(git tag --list 'v*' --sort=v:refname)
+
+          TAG=""
+          if [ -n "$LATEST" ] && ! gh release view "$LATEST" >/dev/null 2>&1; then
+            TAG="$LATEST"
+          elif [ -n "$LATEST" ]; then
+            VERSION="${LATEST#v}"
+            IFS='.' read -r MAJOR MINOR _ <<< "$VERSION"
+            if [ "$MAJOR" != 0 ]; then
+              TARGET="$(git rev-parse "${LATEST}^{commit}")"
+              read -r -a ALIAS_KINDS <<< "$ROLLING_ALIASES"
+              for KIND in "${ALIAS_KINDS[@]}"; do
+                case "$KIND" in
+                  major) ALIAS="v$MAJOR" ;;
+                  minor) ALIAS="v$MAJOR.$MINOR" ;;
+                  *) echo "::error::Unsupported rolling alias kind: $KIND"; exit 1 ;;
+                esac
+                if ! ALIAS_COMMIT="$(git rev-parse --verify "${ALIAS}^{commit}" 2>/dev/null)" ||
+                  [ "$ALIAS_COMMIT" != "$TARGET" ]; then
+                  TAG="$LATEST"
+                  break
+                fi
+              done
+            fi
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          if [ -z "$TAG" ]; then
+            echo "blocked=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "blocked=true" >> "$GITHUB_OUTPUT"
+          ACTIVE="$(gh run list --workflow release.yml --branch "$TAG" --limit 20 --json status --jq '[.[] | select(.status != "completed")] | length')"
+          if [ "$ACTIVE" -gt 0 ]; then
+            echo "::notice::Release $TAG is already queued or in progress."
+            exit 0
+          fi
+          gh workflow run release.yml --ref "$TAG"
+
       - uses: actions/setup-node@v7
+        if: steps.reconcile.outputs.blocked != 'true'
         with:
           node-version: '24'
           cache: npm
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
+        if: steps.reconcile.outputs.blocked != 'true'
 
       - name: Plan release
         id: plan
+        if: steps.reconcile.outputs.blocked != 'true'
         env:
           PLAN_FILE: ${{ runner.temp }}/plan.json
         run: |
@@ -79,6 +146,7 @@ jobs:
 
       - name: Start or recover release workflow
         id: release_target
+        if: steps.reconcile.outputs.blocked != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PLAN_FILE: ${{ runner.temp }}/plan.json
@@ -104,7 +172,7 @@ jobs:
           gh workflow run release.yml --ref "$TAG"
 
       - name: Report skipped cut
-        if: steps.plan.outputs.release != 'true'
+        if: steps.reconcile.outputs.blocked != 'true' && steps.plan.outputs.release != 'true'
         env:
           PLAN_FILE: ${{ runner.temp }}/plan.json
         run: |

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -23,6 +23,11 @@ The tag is created only after the exact bytes of the release commit pass every
 gate, so a failed cut leaves no tag and burns no version number. The next merge
 retries on a fresh version, skipping any already-tagged one.
 
+Before planning another cut, auto-release reconciles the latest immutable tag
+when its GitHub release is missing or its rolling alias has not advanced. It
+does not duplicate an active release run, and a successful release completion
+resumes planning.
+
 Do not push `vX.Y.Z` tags by hand. The pre-push hook refuses them, because a
 hand-pushed tag becomes a public identifier before any gate has run against it.
 

--- a/tests/auto-release.test.ts
+++ b/tests/auto-release.test.ts
@@ -153,4 +153,26 @@ describe('auto-release workflow', () => {
     expect(autoReleaseWorkflow).toContain('gh release view "$TAG"');
     expect(autoReleaseWorkflow).toContain('gh workflow run release.yml --ref "$TAG"');
   });
+
+  it('reconciles the prior incomplete tag before planning another cut', () => {
+    const reconcile = autoReleaseWorkflow.indexOf('name: Reconcile prior release');
+    const plan = autoReleaseWorkflow.indexOf('name: Plan release');
+    expect(reconcile).toBeGreaterThan(-1);
+    expect(reconcile).toBeLessThan(plan);
+    expect(autoReleaseWorkflow).toContain("git tag --list 'v*'");
+    expect(autoReleaseWorkflow).toContain('if ! PACKAGE_VERSION="$(git show');
+    expect(autoReleaseWorkflow).toContain('gh run list --workflow release.yml --branch "$TAG"');
+    expect(autoReleaseWorkflow).toContain("steps.reconcile.outputs.blocked != 'true'");
+    const activeRun = autoReleaseWorkflow.indexOf('gh run list --workflow release.yml');
+    expect(autoReleaseWorkflow.indexOf('gh workflow run release.yml', activeRun)).toBeGreaterThan(
+      activeRun
+    );
+  });
+
+  it('recovers alias failures and resumes after a successful release', () => {
+    expect(autoReleaseWorkflow).toContain('workflow_run:');
+    expect(autoReleaseWorkflow).toContain('workflows: [Release]');
+    expect(autoReleaseWorkflow).toContain("github.event.workflow_run.conclusion == 'success'");
+    expect(autoReleaseWorkflow).toContain('git rev-parse --verify "${ALIAS}^{commit}"');
+  });
 });


### PR DESCRIPTION
## Problem

`auto-release.yml` cuts a new tag on every push to `main`. If a prior release run failed partway — tag pushed but no GitHub Release, or release published but rolling major alias never moved — the next push cut a *new* version on top of the broken one. The incomplete cut stayed incomplete forever, and consumers pinned to the rolling `vN` alias kept resolving to a stale commit.

## Change

A `Reconcile prior release` step runs before any new cut:

- Walks `git tag --list 'v*' --sort=v:refname` and picks the newest tag whose committed `package.json` version matches the tag, so stray or hand-made tags cannot be mistaken for the last real cut.
- Treats that tag as incomplete when either the GitHub Release is missing, or (for non-`0.x`) a configured rolling alias does not point at the tagged commit.
- When incomplete, blocks the new cut and re-dispatches `release.yml` for the existing tag instead, so the broken release is finished rather than buried.

The workflow also now accepts `workflow_run` completions from `Release`, gated on `conclusion == 'success'`, so finishing a recovery run immediately re-evaluates whether a new cut is owed.

## Verification

`npm run typecheck`, `npm run lint`, and `npm test` all green locally on this branch. `tests/auto-release.test.ts` covers the reconcile contract: tag/version-mismatch rejection, missing-release detection, alias-drift detection, and the `workflow_run` success gate.
