### PR TITLE
chore(deps): bump the actions group and follow the pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - id: windows-node-modules
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: node_modules
           key: Windows/node-24/exact-${{ hashFiles('package-lock.json') }}

--- a/tests/ci-workflow.test.ts
+++ b/tests/ci-workflow.test.ts
@@ -113,7 +113,7 @@ describe('CI workflow contract', () => {
     expect(windows).not.toMatch(/^\s*cache:\s*npm\s*$/m);
 
     expect(windows).toContain('id: windows-node-modules');
-    expect(windows).toContain('uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0');
+    expect(windows).toContain('uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0');
     expect(windows).toContain('path: node_modules');
     expect(windows).toContain("key: Windows/node-24/exact-${{ hashFiles('package-lock.json') }}");
     expect(windows).not.toContain('restore-keys');


### PR DESCRIPTION
## Change

Takes the grouped GitHub Actions bump that Dependabot proposed, rebased onto current `main`, plus the test-side changes the bump requires.

The workflow contract tests assert exact pinned action versions. A bump that moves a pin therefore fails them until the expectation moves with it, which is why the Dependabot branches were red on `gate` and `Windows gate`.

Where a bump moved a version that the workflow also references in plain text, those references are aligned too, so the workflow stays internally consistent rather than pinning one version and verifying another.

## Verification

`npm run typecheck`, `npm run lint`, and `npm test` all green locally on this branch.

Supersedes the Dependabot PR for the same group.
