### PR TITLE
fix(ci): use checkout v7 tag for writeback

### DIFF
--- a/.github/workflows/dependabot-dist-writeback.yml
+++ b/.github/workflows/dependabot-dist-writeback.yml
@@ -36,7 +36,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout trusted main
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364badbff7 # v7
+        uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0
@@ -141,7 +141,7 @@ jobs:
 
       - name: Download candidate dist artifact
         if: env.PR_NUMBER != ''
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@v7
         with:
           name: candidate-dist
           path: /tmp/candidate


### PR DESCRIPTION
Fix invalid SHA pin that caused Dependabot writeback to fail.